### PR TITLE
Add qstruct and qclass quantum structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ new language constructs and tooling to support quantum-aware C++ development.
 ## Q++ Highlights
 
 - **`qstruct` and `qclass`** &mdash; Data structures for quantum state
-  storage and manipulation.
+  storage and manipulation.  See
+  [`include/qpp/qstruct.hpp`](include/qpp/qstruct.hpp) for
+  reference implementations.
 - **Probabilistic `bool`** &mdash; Boolean values that represent
   quantum superposition probabilities.
 - **Bitwise gate macros** &mdash; Convenience wrappers for common

--- a/examples/qstruct_demo.cpp
+++ b/examples/qstruct_demo.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include "qpp/qstruct.hpp"
+
+int main() {
+    qpp::qclass reg(1); // one qubit register
+    reg.apply_h(0);     // apply Hadamard
+    reg.apply_x(0);     // apply Pauli-X
+    const auto& st = reg.data();
+    std::cout << "State amplitudes:\n";
+    for (std::size_t i = 0; i < st.amplitude.size(); ++i)
+        std::cout << i << ": " << st.amplitude[i] << '\n';
+    return 0;
+}

--- a/include/qpp/qstruct.hpp
+++ b/include/qpp/qstruct.hpp
@@ -1,0 +1,79 @@
+#ifndef QPP_QSTRUCT_HPP
+#define QPP_QSTRUCT_HPP
+
+#include <complex>
+#include <vector>
+#include <cstddef>
+#include <cmath>
+
+namespace qpp {
+
+/// Basic quantum state container
+struct qstruct {
+    /// Amplitude vector
+    std::vector<std::complex<double>> amplitude;
+
+    /// Construct empty state with optional number of qubits
+    explicit qstruct(std::size_t num_qubits = 0) {
+        reset(num_qubits);
+    }
+
+    /// Reset with new number of qubits
+    void reset(std::size_t num_qubits) {
+        amplitude.assign(std::size_t{1} << num_qubits, {0.0, 0.0});
+        if (!amplitude.empty())
+            amplitude[0] = {1.0, 0.0}; // |0...0>
+    }
+
+    /// Return number of qubits in the state
+    std::size_t qubits() const {
+        std::size_t sz = amplitude.size();
+        std::size_t q = 0;
+        while (sz > 1) {
+            sz >>= 1;
+            ++q;
+        }
+        return q;
+    }
+};
+
+/// Simple quantum register manipulation class
+class qclass {
+public:
+    explicit qclass(std::size_t num_qubits = 0) : state(num_qubits) {}
+
+    /// Access underlying state
+    qstruct& data() { return state; }
+    const qstruct& data() const { return state; }
+
+    /// Apply Pauli-X gate to a qubit
+    void apply_x(std::size_t qubit) {
+        const std::size_t stride = std::size_t{1} << qubit;
+        const std::size_t period = stride << 1;
+        for (std::size_t i = 0; i < state.amplitude.size(); i += period)
+            for (std::size_t j = 0; j < stride; ++j)
+                std::swap(state.amplitude[i + j], state.amplitude[i + j + stride]);
+    }
+
+    /// Apply Hadamard gate to a qubit (not normalized)
+    void apply_h(std::size_t qubit) {
+        const std::size_t stride = std::size_t{1} << qubit;
+        const std::size_t period = stride << 1;
+        const double inv_sqrt2 = 1.0 / std::sqrt(2.0);
+        for (std::size_t i = 0; i < state.amplitude.size(); i += period) {
+            for (std::size_t j = 0; j < stride; ++j) {
+                auto a0 = state.amplitude[i + j];
+                auto a1 = state.amplitude[i + j + stride];
+                state.amplitude[i + j] = (a0 + a1) * inv_sqrt2;
+                state.amplitude[i + j + stride] = (a0 - a1) * inv_sqrt2;
+            }
+        }
+    }
+
+private:
+    qstruct state;
+};
+
+} // namespace qpp
+
+#endif // QPP_QSTRUCT_HPP


### PR DESCRIPTION
## Summary
- implement `qstruct` and `qclass` types for quantum state manipulation
- document them in the README
- add `qstruct_demo.cpp` example

## Testing
- `g++ -std=c++17 examples/qstruct_demo.cpp -Iinclude -o qstruct_demo && ./qstruct_demo`

------
https://chatgpt.com/codex/tasks/task_e_687eb2b4c140832f8272d865fa1a1a46