### PR TITLE
Add demo Q++ parser and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ g++ -Iinclude examples/pbool_demo.cpp -o pbool_demo
 ./pbool_demo
 ```
 
+### Parsing Example
+
+The repository includes a small prototype parser that emits a JSON
+representation of Q++ constructs. Run it on the provided sample file:
+
+```sh
+python3 contrib/qpp_parse_ir.py examples/qpp_parse_example.qpp
+```
+
 Refer to the upstream GCC README for additional information about the
 compiler and licensing.
 

--- a/contrib/qpp_parse_ir.py
+++ b/contrib/qpp_parse_ir.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+# Simple parser/IR generator for the experimental Q++ extensions.
+# This is not a full C++ parser. It only understands a handful of
+# quantum-aware constructs and emits a JSON representation.  The goal
+# is to provide a starting point for more complete frontend work.
+#
+# This file is part of GCC and released under the GPLv3 or later.
+#
+# Usage: qpp_parse_ir.py source.qpp -o out.json
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def parse_file(text: str) -> dict:
+    """Return a very small IR extracted from the given source."""
+    result = {
+        "structs": [],
+        "vars": [],
+        "tasks": [],
+        "operations": [],
+        "qasm": []
+    }
+
+    lines = text.splitlines()
+    qasm_mode = False
+    qasm_buffer = []
+
+    for line in lines:
+        stripped = line.strip()
+
+        if qasm_mode:
+            if '}' in stripped:
+                qasm_buffer.append(stripped.split('}', 1)[0].strip())
+                result["qasm"].append("\n".join(qasm_buffer))
+                qasm_buffer = []
+                qasm_mode = False
+            else:
+                qasm_buffer.append(stripped)
+            continue
+
+        if '__qasm' in stripped:
+            # start raw QASM capture
+            if '{' in stripped:
+                after = stripped.split('{', 1)[1]
+                if '}' in after:
+                    result["qasm"].append(after.split('}', 1)[0].strip())
+                else:
+                    qasm_mode = True
+                    qasm_buffer.append(after.strip())
+            continue
+
+        m = re.search(r'\b(qstruct|qclass|cstruct|cclass)\s+(\w+)', stripped)
+        if m:
+            kind, name = m.groups()
+            result["structs"].append({"kind": kind, "name": name})
+            continue
+
+        m = re.search(r'\b(qregister|cregister|register)\s+(\w+)', stripped)
+        if m:
+            kind, name = m.groups()
+            result["vars"].append({"kind": kind, "name": name})
+            continue
+
+        m = re.search(r'\btask<([A-Z]+)>\s+(\w+)\s*\(', stripped)
+        if m:
+            target, name = m.groups()
+            result["tasks"].append({"name": name, "target": target})
+            continue
+
+        if re.search(r'bool\s+\w+\s*=.*q\[', stripped):
+            result["operations"].append({"type": "probabilistic_bool", "text": stripped})
+            continue
+
+        if '^' in stripped:
+            result["operations"].append({"type": "cx", "text": stripped})
+        if '&' in stripped:
+            result["operations"].append({"type": "toffoli", "text": stripped})
+
+    return result
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Q++ demo parser")
+    ap.add_argument('source', help='Source file to parse')
+    ap.add_argument('-o', '--output', help='Write IR to file')
+    args = ap.parse_args()
+
+    text = Path(args.source).read_text()
+    ir = parse_file(text)
+
+    if args.output:
+        Path(args.output).write_text(json.dumps(ir, indent=2))
+    else:
+        print(json.dumps(ir, indent=2))
+
+
+if __name__ == '__main__':
+    main()
+

--- a/examples/qpp_parse_example.qpp
+++ b/examples/qpp_parse_example.qpp
@@ -1,0 +1,19 @@
+qstruct Token { qbit state; int index; };
+
+qregister qr1;
+cregister cr1;
+
+bool flag = qr1[0];
+
+int result = qr1[0] ^ qr1[1];
+int combo = qr1[0] & qr1[1];
+
+__qasm {
+  H 0;
+  CX 0,1;
+}
+
+task<QPU> kernel() {
+  // placeholder
+}
+


### PR DESCRIPTION
## Summary
- introduce `contrib/qpp_parse_ir.py` as a simple parser/IR generator
- add `examples/qpp_parse_example.qpp` with sample Q++ syntax
- document the parser usage in `README.md`

## Testing
- `python3 -m py_compile contrib/qpp_parse_ir.py`
- `python3 contrib/qpp_parse_ir.py examples/qpp_parse_example.qpp > /tmp/out.json`

------
https://chatgpt.com/codex/tasks/task_e_6882b4997c0c832f8a2c95a43d28ac04