### PR TITLE
Add runtime scheduler prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ new language constructs and tooling to support quantum-aware C++ development.
   quantum logic gates such as `H`, `X`, `CNOT` and others.
 - **Hardware API stubs** &mdash; Placeholder interfaces intended for
   integration with future quantum devices.
+- **Priority-aware scheduler** &mdash; The `qpp::Scheduler` manages
+  `task<*>` functions and supports pause/resume semantics.
 - **`cstruct` and `cclass`** &mdash; Classical-only variants used for
   hybrid modeling alongside quantum structures.
 - **`qregister` and `cregister`** &mdash; Explicit register allocation or
@@ -73,6 +75,9 @@ representation of Q++ constructs. Run it on the provided sample file:
 ```sh
 python3 contrib/qpp_parse_ir.py examples/qpp_parse_example.qpp
 ```
+
+Additional design notes can be found in the files under
+`docs/architecture`, covering the frontend, runtime and hardware API.
 
 Refer to the upstream GCC README for additional information about the
 compiler and licensing.

--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -1,0 +1,32 @@
+# Runtime Overview
+
+This document describes the prototype runtime environment used by Q++.
+It complements the frontend overview and focuses on task execution and
+hardware integration.
+
+## Scheduler
+
+The `qpp::Scheduler` class manages a list of tasks. Each task carries a
+priority and may be paused or resumed. When `run()` is invoked the tasks
+are executed in priority order. This simple model is intended to mimic a
+more complete quantum/classical scheduler that would handle device
+selection and probabilistic control flow.
+
+## Registers
+
+`qregister` and `cregister` provide explicit quantum and classical
+storage. A `qregister` wraps a `qclass` instance and exposes import and
+export helpers so that state can be saved or restored. `cregister` stores
+ordinary integer bits for hybrid algorithms.
+
+## Raw Gate Injection
+
+Code may contain `__qasm { ... }` blocks. The parser collects the
+contents of these blocks and the runtime forwards them unchanged to the
+selected backend.
+
+## Device Stubs
+
+`HardwareStub` is a minimal backend that simply collects emitted QIR
+strings. It serves as a placeholder until real devices are connected.
+

--- a/docs/architecture/03-hardware.md
+++ b/docs/architecture/03-hardware.md
@@ -1,0 +1,23 @@
+# Hardware API
+
+This file sketches the interface expected by future Q++ hardware
+backends. A hardware profile is described in a simple YAML format and
+defines qubit count, supported gates and rate limits.
+
+The runtime emits QIR strings when executing tasks. Real backends would
+translate this intermediate form to device specific commands. For now
+`HardwareStub` simply stores the strings for inspection.
+
+The API is intentionally minimal:
+
+```cpp
+class HardwareStub {
+  void emit(const std::string& qir);
+  std::string result() const;
+};
+```
+
+Implementations may choose to stream operations, perform buffering or
+apply other optimizations. Rate-limit handling and multi-backend support
+are left for future work.
+

--- a/examples/scheduler_demo.cpp
+++ b/examples/scheduler_demo.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include "qpp/scheduler.hpp"
+#include "qpp/qregister.hpp"
+#include "qpp/hardware_stub.hpp"
+
+int main() {
+    qpp::Scheduler sched;
+    qpp::HardwareStub hw;
+    qpp::qregister qr(1);
+
+    sched.add([&]{
+        hw.emit("H 0");
+        qr.data().apply_h(0);
+    }, 1);
+
+    sched.add([&]{
+        hw.emit("X 0");
+        qr.data().apply_x(0);
+    }, 0);
+
+    sched.run();
+    std::cout << hw.result();
+    return 0;
+}

--- a/features.yaml
+++ b/features.yaml
@@ -8,3 +8,27 @@ compiler:
     memory_usage: Predict memory usage and steps during compilation.
   backend_hints:
     annotations: Parse annotations such as @dense or @clifford to influence runtime paths.
+runtime:
+  memory_optimization:
+    sparse_wavefunction_storage: Use sparse data structures when possible.
+    fixed_point_precision: Optionally store amplitudes as fixed point.
+    quidd_compression: Support QuIDD based representation.
+    low_rank_factorization: Factorize large states into low rank terms.
+    disk_paging: Spill very large states to disk.
+  gate_application:
+    gate_fusion: Combine consecutive gates before simulation.
+    sparse_matrix_mult: Sparse multiplication kernels.
+    simd_multithreaded: Utilize SIMD and threads for core kernels.
+    gpu_offload: Allow GPU acceleration when available.
+  simulation_modes:
+    entanglement_forging: Approximate highly entangled sections.
+    clifford_detection: Detect Clifford-only circuits for fast paths.
+    dynamic_switch: Change simulator backend at runtime.
+    timeout_partitioning: Split execution to respect timeouts.
+  debugging_tools:
+    memory_tracker: Track simulator memory usage over time.
+    amplitude_heatmap: Visualize wavefunction amplitudes.
+    gate_profiling: Measure per-gate execution time.
+    branch_map: Show probability branching structure.
+  developer_experience:
+    explain_directive: Emit runtime explanations via #explain.

--- a/include/qpp/cstruct.hpp
+++ b/include/qpp/cstruct.hpp
@@ -1,0 +1,30 @@
+#ifndef QPP_CSTRUCT_HPP
+#define QPP_CSTRUCT_HPP
+
+#include <vector>
+#include <cstddef>
+
+namespace qpp {
+
+/// Purely classical state container
+struct cstruct {
+    std::vector<int> bits;
+
+    explicit cstruct(std::size_t n = 0) : bits(n, 0) {}
+
+    std::size_t size() const { return bits.size(); }
+};
+
+/// Wrapper class similar to qclass but for classical bits
+class cclass {
+    cstruct state;
+public:
+    explicit cclass(std::size_t n = 0) : state(n) {}
+
+    cstruct& data() { return state; }
+    const cstruct& data() const { return state; }
+};
+
+} // namespace qpp
+
+#endif // QPP_CSTRUCT_HPP

--- a/include/qpp/hardware_stub.hpp
+++ b/include/qpp/hardware_stub.hpp
@@ -1,0 +1,27 @@
+#ifndef QPP_HARDWARE_STUB_HPP
+#define QPP_HARDWARE_STUB_HPP
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+namespace qpp {
+
+/// Minimal hardware backend emitting QIR strings
+class HardwareStub {
+public:
+    std::vector<std::string> emitted;
+
+    void emit(const std::string& qir) { emitted.push_back(qir); }
+
+    std::string result() const {
+        std::ostringstream oss;
+        for (const auto& s : emitted)
+            oss << s << "\n";
+        return oss.str();
+    }
+};
+
+} // namespace qpp
+
+#endif // QPP_HARDWARE_STUB_HPP

--- a/include/qpp/qregister.hpp
+++ b/include/qpp/qregister.hpp
@@ -1,0 +1,45 @@
+#ifndef QPP_QREGISTER_HPP
+#define QPP_QREGISTER_HPP
+
+#include "qstruct.hpp"
+#include <vector>
+#include <cstddef>
+
+namespace qpp {
+
+/// Quantum register backed by qclass
+class qregister {
+    qclass reg;
+public:
+    explicit qregister(std::size_t qubits = 0) : reg(qubits) {}
+
+    /// Access underlying quantum class
+    qclass& data() { return reg; }
+    const qclass& data() const { return reg; }
+
+    /// Export state amplitudes
+    std::vector<std::complex<double>> export_state() const {
+        return reg.data().amplitude;
+    }
+
+    /// Import state amplitudes (size must match)
+    void import_state(const std::vector<std::complex<double>>& amp) {
+        reg.data().amplitude = amp;
+    }
+};
+
+/// Classical register storing bits
+class cregister {
+    std::vector<int> bits;
+public:
+    explicit cregister(std::size_t size = 0) : bits(size, 0) {}
+
+    int& operator[](std::size_t i) { return bits[i]; }
+    const int& operator[](std::size_t i) const { return bits[i]; }
+
+    std::size_t size() const { return bits.size(); }
+};
+
+} // namespace qpp
+
+#endif // QPP_QREGISTER_HPP

--- a/include/qpp/scheduler.hpp
+++ b/include/qpp/scheduler.hpp
@@ -1,0 +1,54 @@
+#ifndef QPP_SCHEDULER_HPP
+#define QPP_SCHEDULER_HPP
+
+#include <functional>
+#include <queue>
+#include <vector>
+#include <cstddef>
+
+namespace qpp {
+
+/// Simple task representation
+typedef std::function<void()> TaskFn;
+
+struct Task {
+    TaskFn fn;
+    int priority{0};
+    bool paused{false};
+};
+
+/// Priority-aware task scheduler with pause/resume
+class Scheduler {
+    std::vector<Task> tasks;
+public:
+    /// Add a task with given priority
+    void add(TaskFn fn, int priority = 0) {
+        tasks.push_back({fn, priority, false});
+    }
+
+    /// Execute all tasks in priority order
+    void run() {
+        std::sort(tasks.begin(), tasks.end(),
+                  [](const Task& a, const Task& b) { return a.priority > b.priority; });
+        for (auto& t : tasks) {
+            if (!t.paused)
+                t.fn();
+        }
+    }
+
+    /// Pause a task by index
+    void pause(std::size_t index) {
+        if (index < tasks.size())
+            tasks[index].paused = true;
+    }
+
+    /// Resume a task by index
+    void resume(std::size_t index) {
+        if (index < tasks.size())
+            tasks[index].paused = false;
+    }
+};
+
+} // namespace qpp
+
+#endif // QPP_SCHEDULER_HPP


### PR DESCRIPTION
## Summary
- add qregister/cregister container types
- add simple priority-aware Scheduler runtime
- stub hardware backend for QIR emission
- document runtime and hardware API
- expand features list with runtime capabilities
- provide new scheduler demo example
- mention architecture docs in README

## Testing
- `g++ -std=c++17 -Iinclude examples/scheduler_demo.cpp -o scheduler_demo && ./scheduler_demo`
- `g++ -std=c++17 -Iinclude examples/qstruct_demo.cpp -o qstruct_demo && ./qstruct_demo | head`
- `g++ -std=c++17 -Iinclude examples/pbool_demo.cpp -o pbool_demo && ./pbool_demo`
- `python3 contrib/qpp_parse_ir.py examples/qpp_parse_example.qpp > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_6882ced4616c832f9636c530cef33365