### PR TITLE
Enhance instruction set with new gate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ new language constructs and tooling to support quantum-aware C++ development.
   a value being `true` and provides logical operations that combine
   those probabilities.
 - **Bitwise gate macros** &mdash; Convenience wrappers for common
-  quantum logic gates such as `H`, `X`, `CNOT` and others.
+  quantum logic gates such as `H`, `X`, `Y`, `Z`, `CNOT` and `CCX`.
 - **Hardware API stubs** &mdash; Placeholder interfaces intended for
   integration with future quantum devices.
 - **Priority-aware scheduler** &mdash; The `qpp::Scheduler` manages

--- a/docs/architecture/01-frontend.md
+++ b/docs/architecture/01-frontend.md
@@ -48,3 +48,7 @@ int x = a & b;  // may emit Toffoli when operands are quantum
 ```
 
 Bitwise operators expand to the corresponding quantum gates when required.
+The current implementation maps `^` to a controlled-X gate (CNOT) and
+`&` to a Toffoli gate when the operands reference quantum memory.  Single
+qubit operators such as `|`, `~`, and explicit method calls provide access
+to additional gates including `Y` and `Z`.

--- a/features.yaml
+++ b/features.yaml
@@ -32,3 +32,8 @@ runtime:
     branch_map: Show probability branching structure.
   developer_experience:
     explain_directive: Emit runtime explanations via #explain.
+  instruction_set:
+    pauli_y: Implement single-qubit Y gate.
+    pauli_z: Implement single-qubit Z gate.
+    controlled_x: Controlled-X (CNOT) gate via bitwise ^.
+    toffoli: Controlled-controlled-X gate via bitwise &.

--- a/include/qpp/qstruct.hpp
+++ b/include/qpp/qstruct.hpp
@@ -70,6 +70,56 @@ public:
         }
     }
 
+    /// Apply Pauli-Y gate to a qubit
+    void apply_y(std::size_t qubit) {
+        const std::size_t stride = std::size_t{1} << qubit;
+        const std::size_t period = stride << 1;
+        const std::complex<double> I(0.0, 1.0);
+        for (std::size_t i = 0; i < state.amplitude.size(); i += period) {
+            for (std::size_t j = 0; j < stride; ++j) {
+                auto a0 = state.amplitude[i + j];
+                auto a1 = state.amplitude[i + j + stride];
+                state.amplitude[i + j] = -I * a1;
+                state.amplitude[i + j + stride] = I * a0;
+            }
+        }
+    }
+
+    /// Apply Pauli-Z gate to a qubit
+    void apply_z(std::size_t qubit) {
+        const std::size_t stride = std::size_t{1} << qubit;
+        const std::size_t period = stride << 1;
+        for (std::size_t i = 0; i < state.amplitude.size(); i += period) {
+            for (std::size_t j = 0; j < stride; ++j) {
+                state.amplitude[i + j + stride] *= -1.0;
+            }
+        }
+    }
+
+    /// Apply controlled-X gate
+    void apply_cx(std::size_t control, std::size_t target) {
+        if (control == target)
+            return;
+        for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+            if (((i >> control) & 1) && !((i >> target) & 1)) {
+                std::size_t j = i | (std::size_t{1} << target);
+                std::swap(state.amplitude[i], state.amplitude[j]);
+            }
+        }
+    }
+
+    /// Apply Toffoli (CCX) gate
+    void apply_ccx(std::size_t control1, std::size_t control2, std::size_t target) {
+        if (control1 == target || control2 == target)
+            return;
+        for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+            if (((i >> control1) & 1) && ((i >> control2) & 1) && !((i >> target) & 1)) {
+                std::size_t j = i | (std::size_t{1} << target);
+                std::swap(state.amplitude[i], state.amplitude[j]);
+            }
+        }
+    }
+
 private:
     qstruct state;
 };


### PR DESCRIPTION
## Summary
- implement Y, Z, CNOT and CCX gates in `qclass`
- document new gates in README and frontend spec
- list gate tasks in `features.yaml`

## Testing
- `g++ -Iinclude examples/qstruct_demo.cpp -o qstruct_demo && ./qstruct_demo`
- `g++ -Iinclude /tmp/test_gates.cpp -o /tmp/test_gates && /tmp/test_gates`
- `g++ -Iinclude /tmp/test_ccx.cpp -o /tmp/test_ccx && /tmp/test_ccx`


------
https://chatgpt.com/codex/tasks/task_e_6882da2898d8832fb28ab75ca48ec3f5