### PR TITLE
Make scheduler thread safe

### DIFF
--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -12,6 +12,11 @@ are executed in priority order. This simple model is intended to mimic a
 more complete quantum/classical scheduler that would handle device
 selection and probabilistic control flow.
 
+All public methods are protected by a mutex so that tasks may be added,
+paused or resumed from multiple threads. This ensures thread safety when
+using `task<CPU>`, `task<QPU>`, `task<AUTO>` or `task<MIXED>` functions
+across different components.
+
 ## Registers
 
 `qregister` and `cregister` provide explicit quantum and classical

--- a/include/qpp/scheduler.hpp
+++ b/include/qpp/scheduler.hpp
@@ -5,6 +5,7 @@
 #include <queue>
 #include <vector>
 #include <cstddef>
+#include <mutex>
 
 namespace qpp {
 
@@ -20,17 +21,24 @@ struct Task {
 /// Priority-aware task scheduler with pause/resume
 class Scheduler {
     std::vector<Task> tasks;
+    std::mutex tasks_mutex;
 public:
     /// Add a task with given priority
     void add(TaskFn fn, int priority = 0) {
+        std::lock_guard<std::mutex> lock(tasks_mutex);
         tasks.push_back({fn, priority, false});
     }
 
     /// Execute all tasks in priority order
     void run() {
-        std::sort(tasks.begin(), tasks.end(),
+        std::vector<Task> local;
+        {
+            std::lock_guard<std::mutex> lock(tasks_mutex);
+            local = tasks;
+        }
+        std::sort(local.begin(), local.end(),
                   [](const Task& a, const Task& b) { return a.priority > b.priority; });
-        for (auto& t : tasks) {
+        for (auto& t : local) {
             if (!t.paused)
                 t.fn();
         }
@@ -38,12 +46,14 @@ public:
 
     /// Pause a task by index
     void pause(std::size_t index) {
+        std::lock_guard<std::mutex> lock(tasks_mutex);
         if (index < tasks.size())
             tasks[index].paused = true;
     }
 
     /// Resume a task by index
     void resume(std::size_t index) {
+        std::lock_guard<std::mutex> lock(tasks_mutex);
         if (index < tasks.size())
             tasks[index].paused = false;
     }


### PR DESCRIPTION
## Summary
- make Scheduler thread-safe with a mutex
- document concurrent task usage in runtime overview

## Testing
- `g++ -std=c++17 -Iinclude examples/scheduler_demo.cpp -o scheduler_demo && ./scheduler_demo | head`
- `python3 contrib/qpp_parse_ir.py examples/qpp_parse_example.qpp | head`


------
https://chatgpt.com/codex/tasks/task_e_6882dd413280832fbb77bba22b8f7d4b