### PR TITLE
Add pbool measurement helper

### DIFF
--- a/include/qpp/qstruct.hpp
+++ b/include/qpp/qstruct.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <cstddef>
 #include <cmath>
+#include "pbool.h"
 
 namespace qpp {
 
@@ -118,6 +119,15 @@ public:
                 std::swap(state.amplitude[i], state.amplitude[j]);
             }
         }
+    }
+
+    /// Return probability that the given qubit is measured as 1
+    pbool measure(size_t qubit) const {
+        double p1 = 0.0;
+        for (std::size_t i = 0; i < state.amplitude.size(); ++i)
+            if ((i >> qubit) & 1)
+                p1 += std::norm(state.amplitude[i]);
+        return pbool(p1);
     }
 
 private:

--- a/tests/test_qpp.py
+++ b/tests/test_qpp.py
@@ -61,6 +61,26 @@ int main() {
         self.assertEqual(data['tasks'][0]['target'], 'QPU')
         self.assertEqual(len(data['qasm']), 1)
 
+    def test_measure_pbool(self):
+        code = r"""
+#include <iostream>
+#include "qpp/qstruct.hpp"
+int main() {
+    qpp::qclass qc(1);
+    qc.apply_h(0);
+    auto p = qc.measure(0);
+    std::cout << p.probability() << '\n';
+    return 0;
+}
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / 'meas.cpp'
+            src.write_text(code)
+            exe = Path(tmp) / 'meas'
+            subprocess.run(['g++', '-I', str(include_dir), str(src), '-o', str(exe)], check=True)
+            result = subprocess.run([str(exe)], check=True, capture_output=True, text=True)
+            self.assertTrue(result.stdout.startswith('0.5'))
+
     def test_features_file(self):
         text = (root_dir / 'features.yaml').read_text()
         self.assertIn('circuit_simplification', text)


### PR DESCRIPTION
## Summary
- extend `qclass` with `measure` returning a `pbool`
- exercise measurement helper in unit tests

## Testing
- `pytest tests/test_qpp.py -q`
- ⚠️ `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_6882e1783a0c832f9360b05b38c9bf9e