### PR TITLE
Add periodicity tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential cmake
+          pip install python-dateutil requests
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_periodicity.py
+++ b/tests/test_periodicity.py
@@ -1,0 +1,85 @@
+import subprocess
+import tempfile
+from pathlib import Path
+import unittest
+
+root_dir = Path(__file__).resolve().parents[1]
+include_dir = root_dir / 'include'
+
+class PeriodicityTests(unittest.TestCase):
+    def compile_and_run(self, code, name):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / f"{name}.cpp"
+            src.write_text(code)
+            exe = Path(tmp) / name
+            subprocess.run(['g++', '-std=c++17', '-I', str(include_dir), str(src), '-o', str(exe)], check=True)
+            result = subprocess.run([str(exe)], capture_output=True, text=True, check=True)
+            return result.stdout.strip()
+
+    def test_x_gate_periodicity(self):
+        code = r"""
+#include <iostream>
+#include <complex>
+#include \"qpp/qstruct.hpp\"
+int main() {
+    qpp::qclass qc(1);
+    qc.apply_h(0);
+    auto before = qc.data().amplitude;
+    qc.apply_x(0);
+    qc.apply_x(0);
+    auto after = qc.data().amplitude;
+    bool eq = std::abs(before[0] - after[0]) < 1e-9 &&
+              std::abs(before[1] - after[1]) < 1e-9;
+    std::cout << (eq ? "equal" : "not_equal") << '\n';
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'xperiod')
+        self.assertEqual(out, 'equal')
+
+    def test_h_gate_periodicity(self):
+        code = r"""
+#include <iostream>
+#include <complex>
+#include \"qpp/qstruct.hpp\"
+int main() {
+    qpp::qclass qc(1);
+    auto before = qc.data().amplitude;
+    qc.apply_h(0);
+    qc.apply_h(0);
+    auto after = qc.data().amplitude;
+    bool eq = std::abs(before[0] - after[0]) < 1e-9 &&
+              std::abs(before[1] - after[1]) < 1e-9;
+    std::cout << (eq ? "equal" : "not_equal") << '\n';
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'hperiod')
+        self.assertEqual(out, 'equal')
+
+    def test_cx_gate_periodicity(self):
+        code = r"""
+#include <iostream>
+#include <complex>
+#include <vector>
+#include \"qpp/qstruct.hpp\"
+int main() {
+    qpp::qclass qc(2);
+    qc.apply_h(0);
+    auto before = qc.data().amplitude;
+    qc.apply_cx(0,1);
+    qc.apply_cx(0,1);
+    auto after = qc.data().amplitude;
+    bool eq = true;
+    for (std::size_t i = 0; i < before.size(); ++i)
+        if (std::abs(before[i] - after[i]) >= 1e-9)
+            eq = false;
+    std::cout << (eq ? "equal" : "not_equal") << '\n';
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'cxperiod')
+        self.assertEqual(out, 'equal')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add tests verifying periodic application of X, H and CX gates
- run tests in GitHub Actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_68896cafa824832f85cd03239daac7f0