### PR TITLE
Fix CI missing pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake
-          pip install python-dateutil requests
+          pip install python-dateutil requests pytest
       - name: Run tests
         run: pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake
-          pip install python-dateutil requests pytest
+          pip install python-dateutil requests unidiff pytest
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- install `pytest` in the CI workflow to run Python tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*

------
https://chatgpt.com/codex/tasks/task_e_688970fb0214832fab5e8638a3bda082