### PR TITLE
Fix periodicity test includes

### DIFF
--- a/tests/test_periodicity.py
+++ b/tests/test_periodicity.py
@@ -20,7 +20,7 @@ class PeriodicityTests(unittest.TestCase):
         code = r"""
 #include <iostream>
 #include <complex>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(1);
     qc.apply_h(0);
@@ -41,7 +41,7 @@ int main() {
         code = r"""
 #include <iostream>
 #include <complex>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(1);
     auto before = qc.data().amplitude;
@@ -62,7 +62,7 @@ int main() {
 #include <iostream>
 #include <complex>
 #include <vector>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(2);
     qc.apply_h(0);


### PR DESCRIPTION
## Summary
- remove escaped quotes from qstruct header includes in periodicity tests

## Testing
- `pytest tests/test_periodicity.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil'; No module named 'requests')*
- `pip install python-dateutil requests` *(fails: Could not find a version that satisfies the requirement python-dateutil)*

------
https://chatgpt.com/codex/tasks/task_e_688fffbd0440832f9644e019c2c42f41