### PR TITLE
Add hardware availability fallback and probabilistic sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ new language constructs and tooling to support quantum-aware C++ development.
   quantum logic gates such as `H`, `X`, `Y`, `Z`, `CNOT` and `CCX`.
 - **Hardware API stubs** &mdash; Placeholder interfaces intended for
   integration with future quantum devices.
+- **Hardware detection fallback** &mdash; `qpp::hardware_available()`
+  checks for a usable quantum backend and probabilistic types such as
+  `qpp::pbool` transparently fall back to a classical random number
+  generator with basic glitch detection when none is present.
 - **Priority-aware scheduler** &mdash; The `qpp::Scheduler` manages
   `task<*>` functions, supports pause/resume semantics and allows
   removing or reprioritizing tasks.

--- a/examples/pbool_demo.cpp
+++ b/examples/pbool_demo.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "qpp/pbool.h"
+#include "qpp/hardware.hpp"
 
 int main() {
     qpp::pbool a{0.6};
@@ -8,5 +9,8 @@ int main() {
     std::cout << "P(a=true)=" << a.probability()
               << "\nP(b=true)=" << b.probability()
               << "\nP(a&&b=true)=" << c.probability() << '\n';
+    if (!qpp::hardware_available())
+        std::cout << "Quantum hardware unavailable; using classical RNG\n";
+    std::cout << "Sampled value: " << c.sample() << '\n';
     return static_cast<bool>(c) ? 0 : 1;
 }

--- a/include/qpp/hardware.hpp
+++ b/include/qpp/hardware.hpp
@@ -1,0 +1,15 @@
+#ifndef QPP_HARDWARE_HPP
+#define QPP_HARDWARE_HPP
+
+#include <cstdlib>
+
+namespace qpp {
+/// Check for availability of quantum hardware backend.
+/// Returns true when the environment variable QPP_HW_AVAILABLE is set to "1".
+inline bool hardware_available() {
+    const char* env = std::getenv("QPP_HW_AVAILABLE");
+    return env && env[0] == '1';
+}
+} // namespace qpp
+
+#endif // QPP_HARDWARE_HPP

--- a/include/qpp/pbool.h
+++ b/include/qpp/pbool.h
@@ -2,6 +2,10 @@
 #define QPP_PBOOL_H
 
 #include <algorithm>
+#include <atomic>
+#include <random>
+#include <stdexcept>
+#include "hardware.hpp"
 
 namespace qpp {
 
@@ -9,6 +13,11 @@ namespace qpp {
 /// Stores the probability of the value being `true`.
 class pbool {
     double prob_true;
+    static std::mt19937& rng() {
+        static thread_local std::mt19937 gen(std::random_device{}());
+        return gen;
+    }
+    static std::atomic<int> glitch_count;
 public:
     /// Construct with a probability in [0,1]. Values outside the range are clamped.
     constexpr pbool(double p = 0.0) : prob_true(std::clamp(p, 0.0, 1.0)) {}
@@ -16,8 +25,32 @@ public:
     /// Return the probability that the value is true.
     constexpr double probability() const { return prob_true; }
 
-    /// Convert to classical bool using 0.5 as threshold.
-    explicit constexpr operator bool() const { return prob_true >= 0.5; }
+    /// Convert to classical bool. When quantum hardware is available this
+    /// performs a probabilistic sample; otherwise it falls back to a
+    /// deterministic threshold.
+    explicit operator bool() const {
+        if (hardware_available())
+            return sample();
+        return prob_true >= 0.5;
+    }
+
+    /// Draw a random sample according to the stored probability. A "glitch"
+    /// is detected when the generated number is extremely close to 0 or 1.
+    /// In that case the function guesses the outcome deterministically. After
+    /// several successive glitches a runtime_error is thrown to signal that
+    /// the application should shut down to avoid undefined behavior.
+    bool sample() const {
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        double r = dist(rng());
+        if (r < 1e-6 || r > 1.0 - 1e-6) {
+            if (++glitch_count > 3)
+                throw std::runtime_error(
+                    "Unrecoverable RNG glitch detected, shutting down");
+            return prob_true >= 0.5;
+        }
+        glitch_count = 0;
+        return r < prob_true;
+    }
 
     /// Logical AND on probabilities.
     friend constexpr pbool operator&&(const pbool& a, const pbool& b) {
@@ -34,6 +67,9 @@ public:
         return pbool(1.0 - a.prob_true);
     }
 };
+
+// Definition of the static glitch counter
+inline std::atomic<int> pbool::glitch_count{0};
 
 } // namespace qpp
 

--- a/tests/test_periodicity.py
+++ b/tests/test_periodicity.py
@@ -6,13 +6,17 @@ import unittest
 root_dir = Path(__file__).resolve().parents[1]
 include_dir = root_dir / 'include'
 
+
 class PeriodicityTests(unittest.TestCase):
-    def compile_and_run(self, code, name):
+    def compile_and_run(self, code: str, name: str) -> str:
         with tempfile.TemporaryDirectory() as tmp:
             src = Path(tmp) / f"{name}.cpp"
             src.write_text(code)
             exe = Path(tmp) / name
-            subprocess.run(['g++', '-std=c++17', '-I', str(include_dir), str(src), '-o', str(exe)], check=True)
+            subprocess.run(
+                ['g++', '-std=c++17', '-I', str(include_dir), str(src), '-o', str(exe)],
+                check=True,
+            )
             result = subprocess.run([str(exe)], capture_output=True, text=True, check=True)
             return result.stdout.strip()
 
@@ -20,7 +24,7 @@ class PeriodicityTests(unittest.TestCase):
         code = r"""
 #include <iostream>
 #include <complex>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(1);
     qc.apply_h(0);
@@ -41,7 +45,7 @@ int main() {
         code = r"""
 #include <iostream>
 #include <complex>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(1);
     auto before = qc.data().amplitude;
@@ -62,7 +66,7 @@ int main() {
 #include <iostream>
 #include <complex>
 #include <vector>
-#include \"qpp/qstruct.hpp\"
+#include "qpp/qstruct.hpp"
 int main() {
     qpp::qclass qc(2);
     qc.apply_h(0);
@@ -81,5 +85,7 @@ int main() {
         out = self.compile_and_run(code, 'cxperiod')
         self.assertEqual(out, 'equal')
 
+
 if __name__ == '__main__':
     unittest.main()
+


### PR DESCRIPTION
## Summary
- add `hardware_available` helper to detect quantum hardware via env var
- extend `pbool` with RNG sampling and glitch detection, falling back when no hardware is present
- update probabilistic bool demo and documentation for hardware fallback

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dateutil')*
- `pip install python-dateutil requests` *(fails: Could not find a version that satisfies the requirement python-dateutil)*
- `pytest tests/test_qpp.py -q`
- `pytest tests/test_periodicity.py` *(fails: #include expects "FILENAME" or <FILENAME>)*

------
https://chatgpt.com/codex/tasks/task_e_6894b1a2972c832f964c4608580e3137