### PR TITLE
Add circuit builder support to hardware connectors

### DIFF
--- a/contrib/qpp_parse_ir.py
+++ b/contrib/qpp_parse_ir.py
@@ -53,6 +53,13 @@ def parse_file(text: str) -> dict:
                     qasm_buffer.append(after.strip())
             continue
 
+        m = re.search(r'circuit\.(?:append|push_back)\((\w+)\((.*?)\)\);', stripped)
+        if m:
+            gate, arg_str = m.groups()
+            args = [int(a.strip()) for a in arg_str.split(',') if a.strip()]
+            result["operations"].append({"gate": gate, "args": args})
+            continue
+
         m = re.search(r'\b(qstruct|qclass|cstruct|cclass)\s+(\w+)', stripped)
         if m:
             kind, name = m.groups()

--- a/docs/architecture/03-hardware.md
+++ b/docs/architecture/03-hardware.md
@@ -43,3 +43,93 @@ implementations are provided:
 A `DynamicInitialMapper` chooses between these strategies based on circuit
 size and interaction density and serves as the default when no mapper is
 specified.
+
+## External Providers
+
+Basic support for running programs on external hardware APIs is provided
+through the :class:`HardwareAPI` helper in ``hardware_api.py``.  It can
+connect to either Qiskit or Cirq backends.  Credentials may be supplied
+using ``add_credientials``:
+
+```
+from hardware_api import HardwareAPI
+api = HardwareAPI('qiskit')
+api.add_credientials('qiskit', token='MYTOKEN')
+backend = api.connect()
+```
+
+If no credentials are provided the helper assumes that a backend is
+available locally and falls back to the frameworks' simulators.  This
+mirrors execution on a classical wavefunction simulator or a directly
+attached QPU.
+
+To run on a specific device, call ``select_backend`` with the desired
+backend name.  For example, ``"statevector_simulator"`` chooses the
+statevector simulator in Qiskit while ``"density_matrix"`` selects the
+matching Cirq simulator.
+
+### Running C++/Q++ Programs
+
+Q++ or C++ sources are lowered to OpenQASM before execution.  The
+resulting string can be submitted to an external provider using
+``run_qasm`` or ``run_source``.  ``run_qasm`` accepts a pre-generated
+OpenQASM string while ``run_source`` compiles a Q++/C++ file containing
+``__qasm`` blocks or ``circuit.push_back`` statements and executes the
+resulting program:
+
+```
+from hardware_api import HardwareAPI
+
+api = HardwareAPI('cirq')
+api.select_backend('density_matrix')
+result = api.run_source('program.qpp')[0]
+```
+
+Both helpers execute the program on the configured backend, falling back
+to local simulators when credentials are omitted.
+
+### Example Q++ Source
+
+An end-to-end example Q++ file demonstrates how the helper can be used
+from C++/Q++ code. Circuits in Q++ are vectors of gate operations, so the
+`Circuit` type inherits from `std::vector` and accepts gates via
+`push_back`. The program below targets Qiskit and can be switched to
+Cirq by changing the provider name:
+
+```cpp
+#include "hardware_api.hpp"
+
+int main() {
+  // Replace "qiskit" with "cirq" to target Cirq instead
+  HardwareAPI api("qiskit");
+  api.select_backend("statevector_simulator");
+
+  Circuit circuit; // Circuit inherits from std::vector
+  circuit.push_back(H(0));
+  circuit.push_back(CX(0,1));
+  circuit.push_back(Measure(0,1));
+
+  return 0;
+}
+```
+
+Save the file as ``examples/hardware_api_example.qpp`` and execute it
+using ``run_source``:
+
+```
+from hardware_api import HardwareAPI
+api = HardwareAPI('qiskit')
+api.run_source('examples/hardware_api_example.qpp')
+```
+
+### Testing
+
+The connectors can be exercised with the provided unit tests.  After
+installing optional dependencies (``pip install qiskit cirq``) run:
+
+```
+pytest tests/test_hardware_api.py
+```
+
+The tests automatically skip when the required frameworks are not
+installed, allowing them to run in minimal environments.

--- a/examples/hardware_api_example.qpp
+++ b/examples/hardware_api_example.qpp
@@ -1,0 +1,14 @@
+#include "hardware_api.hpp"
+
+int main() {
+  // Target Qiskit; replace with "cirq" to use Cirq
+  HardwareAPI api("qiskit");
+  api.select_backend("statevector_simulator");
+
+  Circuit circuit; // inherits from std::vector
+  circuit.push_back(H(0));
+  circuit.push_back(CX(0,1));
+  circuit.push_back(Measure(0,1));
+
+  return 0;
+}

--- a/hardware_api.py
+++ b/hardware_api.py
@@ -1,0 +1,213 @@
+"""Hardware API connectors for Qiskit and Cirq.
+
+This module exposes a minimal interface for obtaining either
+Qiskit or Cirq backends.  Credentials can be supplied via
+:func:`add_credientials` (note the intentional spelling to match
+external requirements). If credentials are not provided the
+connectors fall back to the frameworks' default simulators.
+
+Example
+-------
+
+>>> api = HardwareAPI('qiskit')
+>>> api.add_credientials('qiskit', token='MYTOKEN')
+>>> backend = api.connect()
+
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+try:  # Optional imports; the package may not be installed.
+    import qiskit
+except Exception:  # pragma: no cover - the tests handle absence
+    qiskit = None  # type: ignore
+
+try:
+    import cirq
+except Exception:  # pragma: no cover - the tests handle absence
+    cirq = None  # type: ignore
+
+
+@dataclass
+class HardwareAPI:
+    """Connect to a quantum hardware provider.
+
+    Parameters
+    ----------
+    target:
+        ``"qiskit"`` or ``"cirq"``. Determines which backend
+        library to use when :func:`connect` is invoked.
+    """
+
+    target: str
+    credentials: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    backend: str | None = None
+
+    def add_credientials(self, provider: str, **kwargs: Any) -> None:
+        """Store API credentials for a provider.
+
+        Parameters
+        ----------
+        provider:
+            ``"qiskit"`` or ``"cirq"``.
+        kwargs:
+            Keyword arguments containing credential information such as
+            tokens or project identifiers. These are passed directly to
+            the respective framework when establishing a connection.
+        """
+
+        self.credentials[provider.lower()] = kwargs
+
+    def select_backend(self, name: str) -> None:
+        """Select the backend or QPU to run programs on."""
+
+        self.backend = name
+
+    def connect(self) -> Any:
+        """Return a backend instance for the configured target.
+
+        If no credentials were supplied for the selected target the
+        function returns a local simulator.  Supplying credentials
+        enables access to remote hardware when supported by the
+        framework.
+        """
+
+        tgt = self.target.lower()
+        if tgt == "qiskit":
+            if qiskit is None:  # pragma: no cover - runtime check
+                raise ImportError("qiskit is not installed")
+            creds = self.credentials.get("qiskit")
+            if creds and "token" in creds:
+                qiskit.IBMQ.save_account(creds["token"], overwrite=True)
+                provider = qiskit.IBMQ.load_account()
+                backend_name = self.backend or creds.get("backend", "ibmq_qasm_simulator")
+                return provider.get_backend(backend_name)
+            else:
+                backend_name = self.backend or "qasm_simulator"
+                return qiskit.Aer.get_backend(backend_name)
+        elif tgt == "cirq":
+            if cirq is None:  # pragma: no cover - runtime check
+                raise ImportError("cirq is not installed")
+            creds = self.credentials.get("cirq")
+            if creds and "api_key" in creds:
+                engine = cirq.google.Engine(project_id=creds.get("project_id"))
+                processor = self.backend or creds.get("processor_id", "simulator")
+                return engine.get_processor(processor)
+            else:
+                if self.backend == "density_matrix":
+                    return cirq.DensityMatrixSimulator()
+                return cirq.Simulator()
+        else:
+            raise ValueError(f"Unknown target '{self.target}'")
+
+    def run_qasm(self, qasm: str, shots: int = 1024) -> Any:
+        """Execute an OpenQASM program on the selected backend.
+
+        The QASM string can be produced by the Q++/C++ toolchain and
+        submitted here for execution on either simulator or hardware.
+
+        Parameters
+        ----------
+        qasm:
+            An OpenQASM program string.
+        shots:
+            Number of repetitions to execute, passed through to the
+            underlying framework.
+        """
+
+        backend = self.connect()
+        tgt = self.target.lower()
+        if tgt == "qiskit":
+            if qiskit is None:  # pragma: no cover - runtime check
+                raise ImportError("qiskit is not installed")
+            qc = qiskit.QuantumCircuit.from_qasm_str(qasm)
+            job = qiskit.execute(qc, backend=backend, shots=shots)
+            return job.result()
+        elif tgt == "cirq":
+            if cirq is None:  # pragma: no cover - runtime check
+                raise ImportError("cirq is not installed")
+            from cirq.contrib.qasm_import import circuit_from_qasm
+
+            circuit = circuit_from_qasm(qasm)
+            return backend.run(circuit, repetitions=shots)
+        else:
+            raise ValueError(f"Unknown target '{self.target}'")
+
+    def run_source(self, source_path: str, shots: int = 1024) -> List[Any]:
+        """Compile Q++/C++ source and execute on the selected backend.
+
+        Parameters
+        ----------
+        source_path:
+            Path to a source file containing either ``__qasm`` blocks or
+            ``circuit.push_back`` statements.
+        shots:
+            Number of repetitions to execute for each extracted program.
+        """
+
+        from contrib.qpp_parse_ir import parse_file  # Local import to avoid heavy deps
+
+        text = Path(source_path).read_text()
+        ir = parse_file(text)
+        results: List[Any] = []
+        qasms = ir.get("qasm", [])
+        if qasms:
+            for qasm in qasms:
+                results.append(self.run_qasm(qasm, shots=shots))
+            return results
+
+        ops = ir.get("operations", [])
+        if not ops:
+            return results
+
+        max_q = 0
+        max_c = 0
+        for op in ops:
+            args = op.get("args", [])
+            if not args:
+                continue
+            if op["gate"].lower() == "measure" and len(args) > 1:
+                max_q = max(max_q, args[0])
+                max_c = max(max_c, args[1])
+            else:
+                max_q = max(max_q, max(args))
+
+        tgt = self.target.lower()
+        backend = self.connect()
+        if tgt == "qiskit":
+            if qiskit is None:  # pragma: no cover - runtime check
+                raise ImportError("qiskit is not installed")
+            qc = qiskit.QuantumCircuit(max_q + 1, max_c + 1)
+            for op in ops:
+                gate = op["gate"].lower()
+                a = op.get("args", [])
+                if gate == "h":
+                    qc.h(a[0])
+                elif gate == "cx":
+                    qc.cx(a[0], a[1])
+                elif gate == "measure":
+                    qc.measure(a[0], a[1])
+            job = qiskit.execute(qc, backend=backend, shots=shots)
+            results.append(job.result())
+        elif tgt == "cirq":
+            if cirq is None:  # pragma: no cover - runtime check
+                raise ImportError("cirq is not installed")
+            qubits = [cirq.LineQubit(i) for i in range(max_q + 1)]
+            circuit = cirq.Circuit()
+            for op in ops:
+                gate = op["gate"].lower()
+                a = op.get("args", [])
+                if gate == "h":
+                    circuit.append(cirq.H(qubits[a[0]]))
+                elif gate == "cx":
+                    circuit.append(cirq.CNOT(qubits[a[0]], qubits[a[1]]))
+                elif gate == "measure":
+                    circuit.append(cirq.measure(qubits[a[0]], key=f"c{a[1]}"))
+            results.append(backend.run(circuit, repetitions=shots))
+        else:
+            raise ValueError(f"Unknown target '{self.target}'")
+
+        return results

--- a/tests/test_hardware_api.py
+++ b/tests/test_hardware_api.py
@@ -1,0 +1,106 @@
+import importlib
+import sys
+import tempfile
+from pathlib import Path
+import unittest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hardware_api import HardwareAPI
+
+
+class HardwareAPITests(unittest.TestCase):
+    def test_qiskit_simulator_by_default(self):
+        if importlib.util.find_spec("qiskit") is None:
+            self.skipTest("qiskit not installed")
+        api = HardwareAPI("qiskit")
+        backend = api.connect()
+        self.assertIn("simulator", backend.name().lower())
+
+    def test_cirq_simulator_by_default(self):
+        if importlib.util.find_spec("cirq") is None:
+            self.skipTest("cirq not installed")
+        import cirq
+        api = HardwareAPI("cirq")
+        backend = api.connect()
+        self.assertIsInstance(backend, cirq.Simulator)
+
+    def test_run_qasm_on_qiskit(self):
+        if importlib.util.find_spec("qiskit") is None:
+            self.skipTest("qiskit not installed")
+        api = HardwareAPI("qiskit")
+        qasm = (
+            "OPENQASM 2.0; include \"qelib1.inc\"; "
+            "qreg q[1]; creg c[1]; h q[0]; measure q[0] -> c[0];"
+        )
+        result = api.run_qasm(qasm, shots=1)
+        # Result counts should sum to the number of shots
+        self.assertEqual(sum(result.get_counts().values()), 1)
+
+    def test_run_qasm_on_cirq(self):
+        if importlib.util.find_spec("cirq") is None:
+            self.skipTest("cirq not installed")
+        api = HardwareAPI("cirq")
+        qasm = (
+            "OPENQASM 2.0; include \"qelib1.inc\"; "
+            "qreg q[1]; creg c[1]; h q[0]; measure q[0] -> c[0];"
+        )
+        result = api.run_qasm(qasm, shots=1)
+        # The simulator should produce a measurement record
+        self.assertTrue(result.measurements)
+
+    def test_select_backend_qiskit(self):
+        if importlib.util.find_spec("qiskit") is None:
+            self.skipTest("qiskit not installed")
+        api = HardwareAPI("qiskit")
+        api.select_backend("statevector_simulator")
+        backend = api.connect()
+        self.assertIn("statevector", backend.name())
+
+    def test_select_backend_cirq(self):
+        if importlib.util.find_spec("cirq") is None:
+            self.skipTest("cirq not installed")
+        import cirq
+        api = HardwareAPI("cirq")
+        api.select_backend("density_matrix")
+        backend = api.connect()
+        self.assertIsInstance(backend, cirq.DensityMatrixSimulator)
+
+    def test_run_source_qiskit(self):
+        if importlib.util.find_spec("qiskit") is None:
+            self.skipTest("qiskit not installed")
+        api = HardwareAPI("qiskit")
+        code = (
+            "int main() {\n"
+            "Circuit circuit;\n"
+            "circuit.push_back(H(0));\n"
+            "circuit.push_back(CX(0,1));\n"
+            "circuit.push_back(Measure(0,1));\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "prog.qpp"
+            src.write_text(code)
+            result = api.run_source(str(src), shots=1)[0]
+        self.assertEqual(sum(result.get_counts().values()), 1)
+
+    def test_run_source_cirq(self):
+        if importlib.util.find_spec("cirq") is None:
+            self.skipTest("cirq not installed")
+        api = HardwareAPI("cirq")
+        code = (
+            "int main() {\n"
+            "Circuit circuit;\n"
+            "circuit.push_back(H(0));\n"
+            "circuit.push_back(CX(0,1));\n"
+            "circuit.push_back(Measure(0,1));\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "prog.qpp"
+            src.write_text(code)
+            result = api.run_source(str(src), shots=1)[0]
+        self.assertTrue(result.measurements)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse `circuit.push_back(...)` statements in `qpp_parse_ir.py`
- execute circuit-builder Q++ sources via `HardwareAPI.run_source`
- update docs, example, and tests to show `Circuit` inheriting from `std::vector`

## Testing
- `python -m py_compile hardware_api.py`
- `pytest tests/test_hardware_api.py tests/test_qpp.py tests/test_periodicity.py`


------
https://chatgpt.com/codex/tasks/task_e_68b8836f0868832f91a56f4c2e40c935