### PR TITLE
docs: update build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,36 +43,36 @@ new language constructs and tooling to support quantum-aware C++ development.
 
 These features are experimental and not part of upstream GCC.
 
-## Building with CMake
+## Building from source
 
-The workflow mirrors the process referenced in
-[CONTRIBUTING](.github/CONTRIBUTING.md) but uses CMake for configuration.
-A typical build looks like the following:
+The Q++ fork retains GCC's traditional `configure`/`make` build
+system. The process below mirrors the steps outlined in
+[CONTRIBUTING](.github/CONTRIBUTING.md).
 
 ```sh
 # Create a separate build directory
 mkdir build && cd build
 
-# Configure
-cmake ..
+# Configure the build (adjust --enable-languages as needed)
+../configure --disable-multilib --enable-languages=c,c++
 
 # Compile
-cmake --build .
+make -j"$(nproc)"
 
 # Run the test suite
-ctest
+make -k check
 
 # Optionally install
-cmake --install .
+make install
 ```
 
 ### Example
 
 After building, you can compile the demonstration program in
-`examples/pbool_demo.cpp`:
+`examples/pbool_demo.cpp` using the freshly built compiler:
 
 ```sh
-g++ -Iinclude examples/pbool_demo.cpp -o pbool_demo
+./build/gcc/g++ -Iinclude examples/pbool_demo.cpp -o pbool_demo
 ./pbool_demo
 ```
 


### PR DESCRIPTION
## Summary
- replace CMake-only build steps with GCC's traditional `configure`/`make`
- document how to build and test the project from a dedicated directory
- show how to compile and run the `pbool_demo.cpp` example with the freshly built compiler

## Testing
- `g++ -Iinclude examples/pbool_demo.cpp -o pbool_demo && ./pbool_demo`


------
https://chatgpt.com/codex/tasks/task_e_68bccb0acf34832fa833346b9191fac5