### PR TITLE
Use hardware stub in hardware API example

### DIFF
--- a/examples/hardware_api_example.qpp
+++ b/examples/hardware_api_example.qpp
@@ -1,14 +1,16 @@
-#include "hardware_api.hpp"
+#include <iostream>
+#include "qpp/hardware_stub.hpp"
 
 int main() {
-  // Target Qiskit; replace with "cirq" to use Cirq
-  HardwareAPI api("qiskit");
-  api.select_backend("statevector_simulator");
+  qpp::HardwareStub hw;
 
-  Circuit circuit; // inherits from std::vector
-  circuit.push_back(H(0));
-  circuit.push_back(CX(0,1));
-  circuit.push_back(Measure(0,1));
+  // Emit a few QIR instructions
+  hw.emit("H 0");
+  hw.emit("CX 0,1");
+  hw.emit("MEASURE 0,1");
+
+  // Display the collected program
+  std::cout << hw.result();
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- replace `hardware_api.hpp` include with `qpp/hardware_stub.hpp`
- emit simple QIR instructions using `qpp::HardwareStub`
- print the collected program to demonstrate the interface

## Testing
- `g++ -std=c++17 -Iinclude -x c++ examples/hardware_api_example.qpp -o hardware_api_example`


------
https://chatgpt.com/codex/tasks/task_e_68bcce8d26e4832f9f1d420ded53dca7