### PR TITLE
Add missing algorithm include to scheduler

### DIFF
--- a/include/qpp/scheduler.hpp
+++ b/include/qpp/scheduler.hpp
@@ -2,6 +2,7 @@
 #define QPP_SCHEDULER_HPP
 
 #include <functional>
+#include <algorithm>
 #include <queue>
 #include <vector>
 #include <cstddef>


### PR DESCRIPTION
## Summary
- include `<algorithm>` for std::sort usage in scheduler

## Testing
- `g++ -std=c++17 -I include examples/scheduler_demo.cpp -o scheduler_demo`
- `./scheduler_demo`


------
https://chatgpt.com/codex/tasks/task_e_68bcd02a0e20832f83d94060cca4caf2