### PR TITLE
Rename add_credientials to add_credentials

### DIFF
--- a/docs/architecture/03-hardware.md
+++ b/docs/architecture/03-hardware.md
@@ -49,12 +49,13 @@ specified.
 Basic support for running programs on external hardware APIs is provided
 through the :class:`HardwareAPI` helper in ``hardware_api.py``.  It can
 connect to either Qiskit or Cirq backends.  Credentials may be supplied
-using ``add_credientials``:
+using ``add_credentials`` (the earlier ``add_credientials`` spelling is
+still accepted for backward compatibility):
 
 ```
 from hardware_api import HardwareAPI
 api = HardwareAPI('qiskit')
-api.add_credientials('qiskit', token='MYTOKEN')
+api.add_credentials('qiskit', token='MYTOKEN')
 backend = api.connect()
 ```
 

--- a/hardware_api.py
+++ b/hardware_api.py
@@ -2,15 +2,16 @@
 
 This module exposes a minimal interface for obtaining either
 Qiskit or Cirq backends.  Credentials can be supplied via
-:func:`add_credientials` (note the intentional spelling to match
-external requirements). If credentials are not provided the
+:func:`add_credentials`. The previous :func:`add_credientials`
+spelling is preserved as an alias for backward compatibility.
+If credentials are not provided the
 connectors fall back to the frameworks' default simulators.
 
 Example
 -------
 
 >>> api = HardwareAPI('qiskit')
->>> api.add_credientials('qiskit', token='MYTOKEN')
+>>> api.add_credentials('qiskit', token='MYTOKEN')
 >>> backend = api.connect()
 
 """
@@ -46,7 +47,7 @@ class HardwareAPI:
     credentials: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     backend: str | None = None
 
-    def add_credientials(self, provider: str, **kwargs: Any) -> None:
+    def add_credentials(self, provider: str, **kwargs: Any) -> None:
         """Store API credentials for a provider.
 
         Parameters
@@ -60,6 +61,9 @@ class HardwareAPI:
         """
 
         self.credentials[provider.lower()] = kwargs
+
+    # Backward compatibility for prior misspelling
+    add_credientials = add_credentials
 
     def select_backend(self, name: str) -> None:
         """Select the backend or QPU to run programs on."""


### PR DESCRIPTION
## Summary
- rename HardwareAPI.add_credientials to add_credentials and provide alias for backward compatibility
- update documentation and examples to use add_credentials

## Testing
- `pytest tests/test_hardware_api.py`

------
https://chatgpt.com/codex/tasks/task_e_68bcd380a9a8832fac382c6965ab8bd2