### PR TITLE
docs: verify installation using qpp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ file /usr/local/gcc-x86_64/bin/gcc
 /usr/local/gcc-x86_64/bin/gcc -v
 /usr/local/gcc-x86_64/bin/g++ -v
 
-cat > hello.cpp <<'CPP'
+cat > helloworld.qpp <<'QPP'
 #include <iostream>
-int main(){ std::cout << "hello from g++!\n"; }
-CPP
-/usr/local/gcc-x86_64/bin/g++ -std=c++17 hello.cpp -o hello
-./hello
+int main(){ std::cout << "hello from q++!\n"; }
+QPP
+/usr/local/gcc-x86_64/bin/g++ -std=c++17 helloworld.qpp -o helloworld
+./helloworld
 ```
 
 Prebuilt macOS binaries are periodically published on the project's


### PR DESCRIPTION
## Summary
- update README instructions to verify GCC build by compiling a `helloworld.qpp` program

## Testing
- `pytest -q` *(fails: No module named 'dateutil', 'requests')*
- `pip install python-dateutil requests` *(fails: Could not find a version that satisfies the requirement python-dateutil)*
- `pytest tests/test_qpp.py -q`
- `pytest tests/test_hardware_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcdaa42590832fb0e0ee60892af7c6