### PR TITLE
Add backend abstraction and stubs

### DIFF
--- a/include/qpp/backend/Backend.hpp
+++ b/include/qpp/backend/Backend.hpp
@@ -1,0 +1,30 @@
+#ifndef QPP_BACKEND_BACKEND_HPP
+#define QPP_BACKEND_BACKEND_HPP
+
+#include <string>
+
+namespace qpp {
+
+/// Result of executing a circuit on a backend.
+struct RunResult {
+    bool success = true;
+};
+
+/// Abstract base class for all qpp backends.
+class Backend {
+public:
+    virtual ~Backend() = default;
+
+    /// Returns true if the backend is available for use.
+    virtual bool available() const = 0;
+
+    /// Load a circuit description into the backend.
+    virtual void loadCircuit(const std::string& circuit) = 0;
+
+    /// Execute the loaded circuit and return the results.
+    virtual RunResult run() = 0;
+};
+
+} // namespace qpp
+
+#endif // QPP_BACKEND_BACKEND_HPP

--- a/include/qpp/backend/LocalSimBackend.hpp
+++ b/include/qpp/backend/LocalSimBackend.hpp
@@ -1,0 +1,18 @@
+#ifndef QPP_BACKEND_LOCALSIMBACKEND_HPP
+#define QPP_BACKEND_LOCALSIMBACKEND_HPP
+
+#include "Backend.hpp"
+
+namespace qpp {
+
+/// Backend representing a local simulator.
+class LocalSimBackend : public Backend {
+public:
+    bool available() const override;
+    void loadCircuit(const std::string& circuit) override;
+    RunResult run() override;
+};
+
+} // namespace qpp
+
+#endif // QPP_BACKEND_LOCALSIMBACKEND_HPP

--- a/include/qpp/backend/QPUBackend.hpp
+++ b/include/qpp/backend/QPUBackend.hpp
@@ -1,0 +1,18 @@
+#ifndef QPP_BACKEND_QPUBACKEND_HPP
+#define QPP_BACKEND_QPUBACKEND_HPP
+
+#include "Backend.hpp"
+
+namespace qpp {
+
+/// Stub implementation of a quantum processing unit backend.
+class QPUBackend : public Backend {
+public:
+    bool available() const override { return false; }
+    void loadCircuit(const std::string& /*circuit*/) override {}
+    RunResult run() override { return {}; }
+};
+
+} // namespace qpp
+
+#endif // QPP_BACKEND_QPUBACKEND_HPP


### PR DESCRIPTION
## Summary
- define `RunResult` and abstract `Backend` interface
- provide `QPUBackend` stub returning `false` for availability
- declare `LocalSimBackend` interface

## Testing
- `python -m pytest tests/test_qpp.py`

------
https://chatgpt.com/codex/tasks/task_e_68be46cbc46c832f8237d3343332be74