### PR TITLE
Implement LocalSimBackend quantum simulator

### DIFF
--- a/include/qpp/backend/Backend.hpp
+++ b/include/qpp/backend/Backend.hpp
@@ -1,6 +1,7 @@
 #ifndef QPP_BACKEND_BACKEND_HPP
 #define QPP_BACKEND_BACKEND_HPP
 
+#include <map>
 #include <string>
 
 namespace qpp {
@@ -8,6 +9,8 @@ namespace qpp {
 /// Result of executing a circuit on a backend.
 struct RunResult {
     bool success = true;
+    std::map<std::string, double> probabilities;
+    std::map<std::string, unsigned> counts;
 };
 
 /// Abstract base class for all qpp backends.

--- a/include/qpp/backend/LocalSimBackend.hpp
+++ b/include/qpp/backend/LocalSimBackend.hpp
@@ -1,16 +1,41 @@
 #ifndef QPP_BACKEND_LOCALSIMBACKEND_HPP
 #define QPP_BACKEND_LOCALSIMBACKEND_HPP
 
+#include <random>
+#include <string>
+#include <vector>
+
 #include "Backend.hpp"
+#include "../qstruct.hpp"
 
 namespace qpp {
 
 /// Backend representing a local simulator.
 class LocalSimBackend : public Backend {
 public:
-    bool available() const override;
+    using StateVector = qclass;
+
+    LocalSimBackend(int max_qubits = 0, bool use_fftw = false, unsigned seed = 0);
+
+    bool available() const override { return true; }
     void loadCircuit(const std::string& circuit) override;
     RunResult run() override;
+
+    const StateVector& state() const { return psi_; }
+
+private:
+    struct Operation {
+        std::string gate;
+        std::vector<int> args;
+    };
+
+    int maxQubits_ = 0;
+    bool useFFTW_ = false;
+    StateVector psi_{};
+    std::mt19937 rng_{};
+    unsigned shots_ = 0;
+    std::vector<Operation> ops_;
+    std::vector<int> measuredQubits_;
 };
 
 } // namespace qpp

--- a/qpp/backend/LocalSimBackend.cpp
+++ b/qpp/backend/LocalSimBackend.cpp
@@ -1,0 +1,121 @@
+#include "qpp/backend/LocalSimBackend.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <numeric>
+#include <sstream>
+
+namespace qpp {
+
+LocalSimBackend::LocalSimBackend(int max_qubits, bool use_fftw, unsigned seed)
+    : maxQubits_(max_qubits), useFFTW_(use_fftw), rng_(seed) {}
+
+void LocalSimBackend::loadCircuit(const std::string& circuit) {
+    ops_.clear();
+    measuredQubits_.clear();
+    shots_ = 0;
+
+    // Normalize string: split by ';' or newlines
+    int max_qubit = -1;
+    auto process_line = [&](const std::string& line) {
+        std::string cleaned;
+        cleaned.reserve(line.size());
+        for (char c : line) {
+            if (std::isalnum(static_cast<unsigned char>(c)))
+                cleaned.push_back(c);
+            else
+                cleaned.push_back(' ');
+        }
+        std::istringstream ls(cleaned);
+        std::string gate;
+        if (!(ls >> gate))
+            return;
+        std::string lower;
+        lower.resize(gate.size());
+        std::transform(gate.begin(), gate.end(), lower.begin(),
+                       [](unsigned char ch) { return std::tolower(ch); });
+        if (lower == "shots") {
+            ls >> shots_;
+            return;
+        }
+        std::vector<int> args;
+        int v;
+        while (ls >> v)
+            args.push_back(v);
+        if (lower == "measure") {
+            for (int q : args) {
+                measuredQubits_.push_back(q);
+                max_qubit = std::max(max_qubit, q);
+            }
+            return;
+        }
+        for (int q : args)
+            max_qubit = std::max(max_qubit, q);
+        ops_.push_back({lower, args});
+    };
+
+    std::string line;
+    std::stringstream ss(circuit);
+    while (std::getline(ss, line, ';'))
+        process_line(line);
+
+    int required_qubits = max_qubit + 1;
+    if (required_qubits < 0)
+        required_qubits = 0;
+    psi_ = StateVector(required_qubits);
+
+    for (const auto& op : ops_) {
+        if (op.gate == "h" && !op.args.empty())
+            psi_.apply_h(op.args[0]);
+        else if (op.gate == "x" && !op.args.empty())
+            psi_.apply_x(op.args[0]);
+        else if (op.gate == "y" && !op.args.empty())
+            psi_.apply_y(op.args[0]);
+        else if (op.gate == "z" && !op.args.empty())
+            psi_.apply_z(op.args[0]);
+        else if (op.gate == "cx" && op.args.size() >= 2)
+            psi_.apply_cx(op.args[0], op.args[1]);
+        else if (op.gate == "ccx" && op.args.size() >= 3)
+            psi_.apply_ccx(op.args[0], op.args[1], op.args[2]);
+    }
+}
+
+RunResult LocalSimBackend::run() {
+    RunResult result;
+    const auto& amp = psi_.data().amplitude;
+    std::size_t dim = amp.size();
+
+    std::vector<int> meas = measuredQubits_;
+    if (meas.empty()) {
+        int n = psi_.data().qubits();
+        meas.resize(n);
+        std::iota(meas.begin(), meas.end(), 0);
+    }
+
+    if (shots_ == 0) {
+        for (std::size_t i = 0; i < dim; ++i) {
+            double p = std::norm(amp[i]);
+            if (p == 0.0)
+                continue;
+            std::string bits;
+            for (int q : meas)
+                bits.push_back(((i >> q) & 1) ? '1' : '0');
+            result.probabilities[bits] += p;
+        }
+    } else {
+        std::vector<double> probs(dim);
+        for (std::size_t i = 0; i < dim; ++i)
+            probs[i] = std::norm(amp[i]);
+        std::discrete_distribution<std::size_t> dist(probs.begin(), probs.end());
+        for (unsigned s = 0; s < shots_; ++s) {
+            std::size_t idx = dist(rng_);
+            std::string bits;
+            for (int q : meas)
+                bits.push_back(((idx >> q) & 1) ? '1' : '0');
+            result.counts[bits]++;
+        }
+    }
+    return result;
+}
+
+} // namespace qpp


### PR DESCRIPTION
## Summary
- extend backend RunResult with probability and shot count maps
- add fully featured LocalSimBackend with state access
- implement circuit loading and run logic using simple gate set

## Testing
- `g++ -std=c++17 /tmp/test_local.cpp qpp/backend/LocalSimBackend.cpp -Iinclude -o /tmp/test_local && /tmp/test_local | head`
- `pytest tests/test_hardware_api.py::HardwareAPITests::test_run_source_cirq -q`

------
https://chatgpt.com/codex/tasks/task_e_68be4a9a7260832fa187f5e681ec76d7