### PR TITLE
Add big-endian state vector and gate utilities

### DIFF
--- a/qpp/sim/Gates.hpp
+++ b/qpp/sim/Gates.hpp
@@ -1,0 +1,86 @@
+#ifndef QPP_SIM_GATES_HPP
+#define QPP_SIM_GATES_HPP
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cmath>
+
+#include "StateVector.hpp"
+
+namespace qpp {
+namespace sim {
+
+using GateMatrix = std::array<std::complex<double>, 4>; // row-major 2x2
+
+inline const GateMatrix X{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}};
+inline const GateMatrix Z{{{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}}};
+inline const double INV_SQRT2 = 0.70710678118654752440084436210485;
+inline const GateMatrix H{{{INV_SQRT2, 0.0}, {INV_SQRT2, 0.0}, {INV_SQRT2, 0.0}, {-INV_SQRT2, 0.0}}};
+
+/// Apply arbitrary single-qubit gate matrix to qubit q.
+inline void apply_gate(StateVector &psi, const GateMatrix &U, std::size_t q) {
+    std::size_t bit = psi.num_qubits - 1 - q;
+    std::size_t stride = std::size_t{1} << bit;
+    std::size_t period = stride << 1;
+    for (std::size_t i = 0; i < psi.data.size(); i += period) {
+        for (std::size_t j = 0; j < stride; ++j) {
+            auto a0 = psi.data[i + j];
+            auto a1 = psi.data[i + j + stride];
+            psi.data[i + j] = U[0] * a0 + U[1] * a1;
+            psi.data[i + j + stride] = U[2] * a0 + U[3] * a1;
+        }
+    }
+}
+
+/// Apply controlled-NOT with big-endian qubit indexing
+inline void apply_cx(StateVector &psi, std::size_t control, std::size_t target) {
+    if (control == target)
+        return;
+    std::size_t n = psi.num_qubits;
+    std::size_t cbit = n - 1 - control;
+    std::size_t tbit = n - 1 - target;
+    for (std::size_t i = 0; i < psi.data.size(); ++i) {
+        if (((i >> cbit) & 1u) && !((i >> tbit) & 1u)) {
+            std::size_t j = i | (std::size_t{1} << tbit);
+            std::swap(psi.data[i], psi.data[j]);
+        }
+    }
+}
+
+/// Apply Toffoli gate with two controls
+inline void apply_ccx(StateVector &psi, std::size_t c1, std::size_t c2, std::size_t target) {
+    if (c1 == target || c2 == target)
+        return;
+    std::size_t n = psi.num_qubits;
+    std::size_t b1 = n - 1 - c1;
+    std::size_t b2 = n - 1 - c2;
+    std::size_t bt = n - 1 - target;
+    for (std::size_t i = 0; i < psi.data.size(); ++i) {
+        if (((i >> b1) & 1u) && ((i >> b2) & 1u) && !((i >> bt) & 1u)) {
+            std::size_t j = i | (std::size_t{1} << bt);
+            std::swap(psi.data[i], psi.data[j]);
+        }
+    }
+}
+
+/// Apply rotation around Z-axis by given angle to qubit q
+inline void apply_rz(StateVector &psi, double angle, std::size_t q) {
+    std::size_t bit = psi.num_qubits - 1 - q;
+    std::size_t stride = std::size_t{1} << bit;
+    std::size_t period = stride << 1;
+    std::complex<double> phase0 = std::exp(std::complex<double>(0, -angle / 2));
+    std::complex<double> phase1 = std::exp(std::complex<double>(0, angle / 2));
+    for (std::size_t i = 0; i < psi.data.size(); i += period) {
+        for (std::size_t j = 0; j < stride; ++j) {
+            psi.data[i + j] *= phase0;
+            psi.data[i + j + stride] *= phase1;
+        }
+    }
+}
+
+} // namespace sim
+} // namespace qpp
+
+#endif // QPP_SIM_GATES_HPP

--- a/qpp/sim/StateVector.hpp
+++ b/qpp/sim/StateVector.hpp
@@ -1,0 +1,81 @@
+#ifndef QPP_SIM_STATEVECTOR_HPP
+#define QPP_SIM_STATEVECTOR_HPP
+
+#include <complex>
+#include <vector>
+#include <cmath>
+#include <cstddef>
+
+namespace qpp {
+namespace sim {
+
+/// Simple state vector representation using big-endian qubit ordering.
+struct StateVector {
+    /// Amplitude data in computational basis order
+    std::vector<std::complex<double>> data;
+    /// Number of qubits represented by the state
+    std::size_t num_qubits = 0;
+
+    /// Allocate space for given number of qubits and reset to |0...0>
+    void allocate(std::size_t nq) {
+        num_qubits = nq;
+        data.assign(std::size_t{1} << nq, {0.0, 0.0});
+        if (!data.empty())
+            data[0] = {1.0, 0.0};
+    }
+
+    /// Normalize amplitudes so that total probability equals one
+    void normalize() {
+        double norm = 0.0;
+        for (const auto &amp : data)
+            norm += std::norm(amp);
+        if (norm == 0.0)
+            return;
+        double inv = 1.0 / std::sqrt(norm);
+        for (auto &amp : data)
+            amp *= inv;
+    }
+
+    /// Probability of a specific basis state index
+    double probability(std::size_t index) const {
+        return std::norm(data[index]);
+    }
+
+    /// Probabilities for all basis states
+    std::vector<double> probabilities() const {
+        std::vector<double> probs(data.size());
+        for (std::size_t i = 0; i < data.size(); ++i)
+            probs[i] = std::norm(data[i]);
+        return probs;
+    }
+
+    /// Measurement probability distribution for selected qubits.
+    /// Qubits are specified using big-endian order (q=0 is highest bit).
+    /// Returns a vector of size 2^k where k = qubits.size(), with
+    /// probabilities ordered in big-endian bit order of the measured qubits.
+    std::vector<double> measure_probs(const std::vector<int> &qubits) const {
+        if (qubits.empty())
+            return probabilities();
+        std::size_t k = qubits.size();
+        std::vector<double> probs(std::size_t{1} << k, 0.0);
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            double p = std::norm(data[i]);
+            if (p == 0.0)
+                continue;
+            std::size_t outcome = 0;
+            for (std::size_t j = 0; j < k; ++j) {
+                int q = qubits[j];
+                std::size_t bit = num_qubits - 1 - static_cast<std::size_t>(q);
+                std::size_t val = (i >> bit) & 1u;
+                outcome = (outcome << 1) | val;
+            }
+            probs[outcome] += p;
+        }
+        return probs;
+    }
+};
+
+} // namespace sim
+} // namespace qpp
+
+#endif // QPP_SIM_STATEVECTOR_HPP


### PR DESCRIPTION
## Summary
- Introduce `StateVector` with allocation, normalization, and measurement probability helpers using big-endian qubit ordering
- Provide gate operations including single-qubit matrices `X`, `Z`, `H`, plus `apply_cx`, `apply_ccx`, and `apply_rz`

## Testing
- `g++ -std=c++17 -I. -Iinclude /tmp/test.cpp -c -o /tmp/test.o`


------
https://chatgpt.com/codex/tasks/task_e_68be4f5dbacc832fae2852134540d0cc