### PR TITLE
Add FFT-based period finding and modular sieve filtering

### DIFF
--- a/include/qpp/sim/Characters.hpp
+++ b/include/qpp/sim/Characters.hpp
@@ -19,8 +19,9 @@ inline std::vector<int> prime_sieve_frequency(int limit) {
     sieve[0] = sieve[1] = false;
     for (int p = 2; p * p <= limit; ++p) {
         if (sieve[p]) {
-            for (int i = p * p; i <= limit; i += p)
-                sieve[i] = false;
+            for (int i = p * p; i <= limit; ++i)
+                if (proj_mod_eq(i, 0, p))
+                    sieve[i] = false;
         }
     }
     std::vector<int> primes;

--- a/include/qpp/sim/FFT.hpp
+++ b/include/qpp/sim/FFT.hpp
@@ -26,6 +26,12 @@ public:
 #endif
     }
 
+    /// Compute real-to-complex FFT of a real input sequence.
+    std::vector<std::complex<double>> rfft(const std::vector<double>& in) const {
+        std::vector<std::complex<double>> complex_in(in.begin(), in.end());
+        return forward(complex_in);
+    }
+
     std::vector<std::complex<double>>
     inverse(const std::vector<std::complex<double>>& in) const {
 #ifdef QPP_FFTW_AVAILABLE

--- a/include/qpp/sim/PeriodFinding.hpp
+++ b/include/qpp/sim/PeriodFinding.hpp
@@ -1,0 +1,42 @@
+#ifndef QPP_SIM_PERIODFINDING_HPP
+#define QPP_SIM_PERIODFINDING_HPP
+
+#include <cstddef>
+#include <complex>
+#include <vector>
+#include <cmath>
+
+#include "FFT.hpp"
+
+namespace qpp::sim {
+
+/// Estimate the period of f(x) = a^x mod N using an FFT approach.
+inline std::size_t period_finding(unsigned a, unsigned N, std::size_t samples) {
+    std::vector<double> sequence(samples);
+    unsigned value = 1;
+    for (std::size_t i = 0; i < samples; ++i) {
+        sequence[i] = static_cast<double>(value);
+        value = static_cast<unsigned long long>(value) * a % N;
+    }
+
+    FFT fft;
+    auto spectrum = fft.rfft(sequence);
+
+    double max_mag = 0.0;
+    std::size_t max_index = 0;
+    for (std::size_t i = 1; i < spectrum.size(); ++i) {
+        double mag = std::norm(spectrum[i]);
+        if (mag > max_mag) {
+            max_mag = mag;
+            max_index = i;
+        }
+    }
+
+    if (max_index == 0)
+        return 0;
+    return samples / max_index;
+}
+
+} // namespace qpp::sim
+
+#endif // QPP_SIM_PERIODFINDING_HPP


### PR DESCRIPTION
## Summary
- refine prime sieve to filter composites using congruence check
- add real FFT helper and FFT-based period finding example

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5751de38832f8b961d9ac9195ee5