### PR TITLE
Add circuit and program API with sampling

### DIFF
--- a/include/qpp/api/Circuit.hpp
+++ b/include/qpp/api/Circuit.hpp
@@ -1,0 +1,57 @@
+#ifndef QPP_API_CIRCUIT_HPP
+#define QPP_API_CIRCUIT_HPP
+
+#include <string>
+#include <vector>
+#include <sstream>
+
+namespace qpp {
+namespace api {
+
+/// Representation of a quantum circuit consisting of a list of gates.
+struct Gate {
+    std::string op;              ///< Gate operation code
+    std::vector<int> qubits;     ///< Target qubits
+    std::vector<double> params;  ///< Optional gate parameters
+};
+
+/// Simple circuit container supporting qubit allocation and gate recording.
+struct Circuit {
+    int numQubits = 0;                 ///< Number of allocated qubits
+    std::vector<Gate> gates;           ///< Sequence of gates
+    unsigned shots = 0;                ///< Optional shots configuration
+
+    /// Allocate additional qubits and return first allocated index.
+    int allocateQubits(int n) {
+        int start = numQubits;
+        numQubits += n;
+        return start;
+    }
+
+    /// Append a gate to the circuit.
+    void addGate(const std::string& op, const std::vector<int>& qs,
+                 const std::vector<double>& ps = {}) {
+        gates.push_back({op, qs, ps});
+    }
+
+    /// Convert circuit to a textual representation understood by backends.
+    std::string toString() const {
+        std::ostringstream ss;
+        if (shots > 0)
+            ss << "shots " << shots << ';';
+        for (const auto& g : gates) {
+            ss << g.op;
+            for (int q : g.qubits)
+                ss << ' ' << q;
+            for (double p : g.params)
+                ss << ' ' << p;
+            ss << ';';
+        }
+        return ss.str();
+    }
+};
+
+} // namespace api
+} // namespace qpp
+
+#endif // QPP_API_CIRCUIT_HPP

--- a/include/qpp/api/Program.hpp
+++ b/include/qpp/api/Program.hpp
@@ -1,0 +1,48 @@
+#ifndef QPP_API_PROGRAM_HPP
+#define QPP_API_PROGRAM_HPP
+
+#include <random>
+#include <string>
+
+#include "qpp/api/Circuit.hpp"
+#include "qpp/api/Sampler.hpp"
+#include "qpp/backend/Backend.hpp"
+#include "qpp/backend/LocalSimBackend.hpp"
+
+namespace qpp {
+namespace api {
+
+/// Program ties a Circuit to execution backends.
+class Program {
+public:
+    Program(const Circuit& c, Backend* qpu, LocalSimBackend* sim)
+        : circuit_(c), qpuBackend_(qpu), simBackend_(sim) {}
+
+    /// Execute the circuit on the available backend.
+    RunResult execute() {
+        std::string text = circuit_.toString();
+        RunResult result;
+        if (qpuBackend_ && qpuBackend_->available()) {
+            qpuBackend_->loadCircuit(text);
+            result = qpuBackend_->run();
+        } else if (simBackend_) {
+            simBackend_->loadCircuit(text);
+            result = simBackend_->run();
+        }
+        if (circuit_.shots > 0 && result.counts.empty() && !result.probabilities.empty())
+            result.counts = Sampler::sample(result.probabilities, circuit_.shots, rng_);
+        return result;
+    }
+
+    Circuit circuit_;
+
+private:
+    Backend* qpuBackend_ = nullptr;
+    LocalSimBackend* simBackend_ = nullptr;
+    std::mt19937 rng_{std::random_device{}()};
+};
+
+} // namespace api
+} // namespace qpp
+
+#endif // QPP_API_PROGRAM_HPP

--- a/include/qpp/api/Sampler.hpp
+++ b/include/qpp/api/Sampler.hpp
@@ -1,0 +1,38 @@
+#ifndef QPP_API_SAMPLER_HPP
+#define QPP_API_SAMPLER_HPP
+
+#include <map>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace qpp {
+namespace api {
+
+/// Utility for sampling measurement outcomes from probability distributions.
+struct Sampler {
+    template <typename RNG>
+    static std::map<std::string, unsigned>
+    sample(const std::map<std::string, double>& probs, unsigned shots, RNG& rng) {
+        std::vector<std::string> outcomes;
+        std::vector<double> weights;
+        outcomes.reserve(probs.size());
+        weights.reserve(probs.size());
+        for (const auto& kv : probs) {
+            outcomes.push_back(kv.first);
+            weights.push_back(kv.second);
+        }
+        std::discrete_distribution<std::size_t> dist(weights.begin(), weights.end());
+        std::map<std::string, unsigned> counts;
+        for (unsigned i = 0; i < shots; ++i) {
+            std::size_t idx = dist(rng);
+            counts[outcomes[idx]]++;
+        }
+        return counts;
+    }
+};
+
+} // namespace api
+} // namespace qpp
+
+#endif // QPP_API_SAMPLER_HPP

--- a/tests/test_qpp.py
+++ b/tests/test_qpp.py
@@ -81,6 +81,30 @@ int main() {
             result = subprocess.run([str(exe)], check=True, capture_output=True, text=True)
             self.assertTrue(result.stdout.startswith('0.5'))
 
+    def test_program_execute_local(self):
+        code = r"""
+#include <iostream>
+#include "qpp/api/Program.hpp"
+int main() {
+    qpp::api::Circuit circ;
+    circ.allocateQubits(1);
+    circ.addGate("h", {0});
+    circ.addGate("measure", {0});
+    qpp::LocalSimBackend sim;
+    qpp::api::Program prog(circ, nullptr, &sim);
+    auto res = prog.execute();
+    std::cout << res.probabilities["0"] << ' ' << res.probabilities["1"] << '\n';
+    return 0;
+}
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / 'prog.cpp'
+            src.write_text(code)
+            exe = Path(tmp) / 'prog'
+            subprocess.run(['g++', '-I', str(include_dir), str(src), str(root_dir / 'qpp/backend/LocalSimBackend.cpp'), '-o', str(exe)], check=True)
+            result = subprocess.run([str(exe)], check=True, capture_output=True, text=True)
+            self.assertIn('0.5', result.stdout)
+
     def test_features_file(self):
         text = (root_dir / 'features.yaml').read_text()
         self.assertIn('circuit_simplification', text)


### PR DESCRIPTION
## Summary
- add Circuit API to track qubits, gates and shots
- implement Program that chooses between QPU and local backends with sampling
- introduce Sampler helper and test local execution of Program

## Testing
- `pytest tests/test_qpp.py`

------
https://chatgpt.com/codex/tasks/task_e_68be597c57a8832f91854b4707855263