### PR TITLE
feat: add noise modeling and square wave encoding

### DIFF
--- a/include/qpp/backend/LocalSimBackend.hpp
+++ b/include/qpp/backend/LocalSimBackend.hpp
@@ -15,7 +15,9 @@ class LocalSimBackend : public Backend {
 public:
     using StateVector = qclass;
 
-    LocalSimBackend(int max_qubits = 0, bool use_fftw = false, unsigned seed = 0);
+    LocalSimBackend(int max_qubits = 0, bool use_fftw = false, unsigned seed = 0,
+                    double phase_jitter = 0.0, double amplitude_noise = 0.0,
+                    double depolarizing = 0.0);
 
     bool available() const override { return true; }
     void loadCircuit(const std::string& circuit) override;
@@ -36,6 +38,13 @@ private:
     unsigned shots_ = 0;
     std::vector<Operation> ops_;
     std::vector<int> measuredQubits_;
+
+    // Noise parameters
+    double phaseJitter_ = 0.0;
+    double amplitudeNoise_ = 0.0;
+    double depolarizingProb_ = 0.0;
+
+    void applyNoise();
 };
 
 } // namespace qpp

--- a/include/qpp/sim/Encodings.hpp
+++ b/include/qpp/sim/Encodings.hpp
@@ -2,6 +2,7 @@
 #define QPP_SIM_ENCODINGS_HPP
 
 #include <cmath>
+#include <functional>
 
 namespace qpp::sim {
 
@@ -17,11 +18,16 @@ struct LFC {
     double freq(double value) const { return scale * value; }
 
     /// Encode value at time t as either sine or square wave sample
-    double encode(double value, double t) const {
+    /// \param square When true, force square wave regardless of member setting
+    /// \param filter Optional hook to suppress higher harmonics
+    double encode(double value, double t, bool square = false,
+                  const std::function<double(double)>& filter = nullptr) const {
         constexpr double PI2 = 2.0 * 3.14159265358979323846;
         double phase = PI2 * freq(value) * t;
         double s = std::sin(phase);
-        return squareWave ? (s >= 0.0 ? 1.0 : -1.0) : s;
+        bool useSquare = square || squareWave;
+        double out = useSquare ? (s >= 0.0 ? 1.0 : -1.0) : s;
+        return filter ? filter(out) : out;
     }
 
     /// Recover value from frequency
@@ -42,11 +48,16 @@ struct LogFC {
     }
 
     /// Encode value at time t as either sine or square wave sample
-    double encode(double value, double t) const {
+    /// \param square When true, force square wave regardless of member setting
+    /// \param filter Optional hook to suppress higher harmonics
+    double encode(double value, double t, bool square = false,
+                  const std::function<double(double)>& filter = nullptr) const {
         constexpr double PI2 = 2.0 * 3.14159265358979323846;
         double phase = PI2 * freq(value) * t;
         double s = std::sin(phase);
-        return squareWave ? (s >= 0.0 ? 1.0 : -1.0) : s;
+        bool useSquare = square || squareWave;
+        double out = useSquare ? (s >= 0.0 ? 1.0 : -1.0) : s;
+        return filter ? filter(out) : out;
     }
 
     /// Recover value from frequency

--- a/qpp/backend/LocalSimBackend.cpp
+++ b/qpp/backend/LocalSimBackend.cpp
@@ -4,11 +4,17 @@
 #include <cctype>
 #include <numeric>
 #include <sstream>
+#include <complex>
+#include <cmath>
 
 namespace qpp {
 
-LocalSimBackend::LocalSimBackend(int max_qubits, bool use_fftw, unsigned seed)
-    : maxQubits_(max_qubits), useFFTW_(use_fftw), rng_(seed) {}
+LocalSimBackend::LocalSimBackend(int max_qubits, bool use_fftw, unsigned seed,
+                                 double phase_jitter, double amplitude_noise,
+                                 double depolarizing)
+    : maxQubits_(max_qubits), useFFTW_(use_fftw), rng_(seed),
+      phaseJitter_(phase_jitter), amplitudeNoise_(amplitude_noise),
+      depolarizingProb_(depolarizing) {}
 
 void LocalSimBackend::loadCircuit(const std::string& circuit) {
     ops_.clear();
@@ -77,6 +83,45 @@ void LocalSimBackend::loadCircuit(const std::string& circuit) {
             psi_.apply_cx(op.args[0], op.args[1]);
         else if (op.gate == "ccx" && op.args.size() >= 3)
             psi_.apply_ccx(op.args[0], op.args[1], op.args[2]);
+
+        if (phaseJitter_ != 0.0 || amplitudeNoise_ != 0.0 ||
+            depolarizingProb_ != 0.0)
+            applyNoise();
+    }
+}
+
+void LocalSimBackend::applyNoise() {
+    auto& amp = psi_.data().amplitude;
+
+    if (phaseJitter_ != 0.0) {
+        std::normal_distribution<double> dist(0.0, phaseJitter_);
+        double phi = dist(rng_);
+        std::complex<double> phase = std::polar(1.0, phi);
+        for (auto& a : amp)
+            a *= phase;
+    }
+
+    if (amplitudeNoise_ != 0.0) {
+        std::normal_distribution<double> dist(0.0, amplitudeNoise_);
+        for (auto& a : amp)
+            a += std::complex<double>(dist(rng_), dist(rng_));
+    }
+
+    if (depolarizingProb_ != 0.0) {
+        std::uniform_real_distribution<double> dist(0.0, 1.0);
+        if (dist(rng_) < depolarizingProb_) {
+            std::normal_distribution<double> nd(0.0, 1.0);
+            double norm = 0.0;
+            for (auto& a : amp) {
+                double re = nd(rng_);
+                double im = nd(rng_);
+                a = {re, im};
+                norm += re * re + im * im;
+            }
+            norm = std::sqrt(norm);
+            for (auto& a : amp)
+                a /= norm;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- extend LocalSimBackend with phase jitter, amplitude noise and depolarizing parameters
- allow noise injection during simulation
- add square-wave and filtering hooks to encoding utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateutil')*
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5bae388c832f82f49b2dbc39e73d