### PR TITLE
Add vectorization hooks and backend selection

### DIFF
--- a/include/qpp/sim/FFT.hpp
+++ b/include/qpp/sim/FFT.hpp
@@ -6,19 +6,27 @@
 
 namespace qpp::sim {
 
+#ifdef QPP_SINGLE_PRECISION
+using real_t = float;
+#else
+using real_t = double;
+#endif
+using complex_t = std::complex<real_t>;
+
 /// Thin wrapper around FFT libraries. Falls back to a no-op implementation
-/// when neither FFTW nor kissfft is available.
+/// when no supported FFT backend is available.
 class FFT {
 public:
-    std::vector<std::complex<double>>
-    forward(const std::vector<std::complex<double>>& in) const {
-#ifdef QPP_FFTW_AVAILABLE
+    std::vector<complex_t>
+    forward(const std::vector<complex_t>& in) const {
+#if defined(QPP_USE_FFTW)
         // Implementation using FFTW would go here
-        // Placeholder returning input
         return in;
-#elif defined(QPP_KISSFFT_AVAILABLE)
-        // Implementation using kissfft would go here
-        // Placeholder returning input
+#elif defined(QPP_USE_ONEMKL)
+        // Implementation using oneMKL would go here
+        return in;
+#elif defined(QPP_USE_CUFFT)
+        // Implementation using cuFFT would go here
         return in;
 #else
         // No FFT library available
@@ -27,18 +35,21 @@ public:
     }
 
     /// Compute real-to-complex FFT of a real input sequence.
-    std::vector<std::complex<double>> rfft(const std::vector<double>& in) const {
-        std::vector<std::complex<double>> complex_in(in.begin(), in.end());
+    std::vector<complex_t> rfft(const std::vector<real_t>& in) const {
+        std::vector<complex_t> complex_in(in.begin(), in.end());
         return forward(complex_in);
     }
 
-    std::vector<std::complex<double>>
-    inverse(const std::vector<std::complex<double>>& in) const {
-#ifdef QPP_FFTW_AVAILABLE
+    std::vector<complex_t>
+    inverse(const std::vector<complex_t>& in) const {
+#if defined(QPP_USE_FFTW)
         // Implementation using FFTW would go here
         return in;
-#elif defined(QPP_KISSFFT_AVAILABLE)
-        // Implementation using kissfft would go here
+#elif defined(QPP_USE_ONEMKL)
+        // Implementation using oneMKL would go here
+        return in;
+#elif defined(QPP_USE_CUFFT)
+        // Implementation using cuFFT would go here
         return in;
 #else
         return in;

--- a/qpp/sim/Gates.hpp
+++ b/qpp/sim/Gates.hpp
@@ -6,25 +6,38 @@
 #include <complex>
 #include <cstddef>
 #include <cmath>
+#if defined(QPP_ENABLE_OPENMP) || defined(QPP_ENABLE_GPU)
+#include <omp.h>
+#endif
 
 #include "StateVector.hpp"
 
 namespace qpp {
 namespace sim {
 
-using GateMatrix = std::array<std::complex<double>, 4>; // row-major 2x2
+using GateMatrix = std::array<complex_t, 4>; // row-major 2x2
 
-inline const GateMatrix X{{{0.0, 0.0}, {1.0, 0.0}, {1.0, 0.0}, {0.0, 0.0}}};
-inline const GateMatrix Z{{{1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}}};
-inline const double INV_SQRT2 = 0.70710678118654752440084436210485;
-inline const GateMatrix H{{{INV_SQRT2, 0.0}, {INV_SQRT2, 0.0}, {INV_SQRT2, 0.0}, {-INV_SQRT2, 0.0}}};
+inline const GateMatrix X{{ complex_t{0.0, 0.0}, complex_t{1.0, 0.0},
+                            complex_t{1.0, 0.0}, complex_t{0.0, 0.0} }};
+inline const GateMatrix Z{{ complex_t{1.0, 0.0}, complex_t{0.0, 0.0},
+                            complex_t{0.0, 0.0}, complex_t{-1.0, 0.0} }};
+constexpr real_t INV_SQRT2 =
+    static_cast<real_t>(0.70710678118654752440084436210485L);
+inline const GateMatrix H{{ complex_t{INV_SQRT2, 0.0}, complex_t{INV_SQRT2, 0.0},
+                            complex_t{INV_SQRT2, 0.0}, complex_t{-INV_SQRT2, 0.0} }};
 
 /// Apply arbitrary single-qubit gate matrix to qubit q.
 inline void apply_gate(StateVector &psi, const GateMatrix &U, std::size_t q) {
     std::size_t bit = psi.num_qubits - 1 - q;
     std::size_t stride = std::size_t{1} << bit;
     std::size_t period = stride << 1;
-    for (std::size_t i = 0; i < psi.data.size(); i += period) {
+    std::size_t total = psi.data.size();
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for collapse(2) schedule(static)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
+    for (std::size_t i = 0; i < total; i += period) {
         for (std::size_t j = 0; j < stride; ++j) {
             auto a0 = psi.data[i + j];
             auto a1 = psi.data[i + j + stride];
@@ -41,6 +54,11 @@ inline void apply_cx(StateVector &psi, std::size_t control, std::size_t target) 
     std::size_t n = psi.num_qubits;
     std::size_t cbit = n - 1 - control;
     std::size_t tbit = n - 1 - target;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
     for (std::size_t i = 0; i < psi.data.size(); ++i) {
         if (((i >> cbit) & 1u) && !((i >> tbit) & 1u)) {
             std::size_t j = i | (std::size_t{1} << tbit);
@@ -57,6 +75,11 @@ inline void apply_ccx(StateVector &psi, std::size_t c1, std::size_t c2, std::siz
     std::size_t b1 = n - 1 - c1;
     std::size_t b2 = n - 1 - c2;
     std::size_t bt = n - 1 - target;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
     for (std::size_t i = 0; i < psi.data.size(); ++i) {
         if (((i >> b1) & 1u) && ((i >> b2) & 1u) && !((i >> bt) & 1u)) {
             std::size_t j = i | (std::size_t{1} << bt);
@@ -66,12 +89,17 @@ inline void apply_ccx(StateVector &psi, std::size_t c1, std::size_t c2, std::siz
 }
 
 /// Apply rotation around Z-axis by given angle to qubit q
-inline void apply_rz(StateVector &psi, double angle, std::size_t q) {
+inline void apply_rz(StateVector &psi, real_t angle, std::size_t q) {
     std::size_t bit = psi.num_qubits - 1 - q;
     std::size_t stride = std::size_t{1} << bit;
     std::size_t period = stride << 1;
-    std::complex<double> phase0 = std::exp(std::complex<double>(0, -angle / 2));
-    std::complex<double> phase1 = std::exp(std::complex<double>(0, angle / 2));
+    complex_t phase0 = std::exp(complex_t{0, -angle / 2});
+    complex_t phase1 = std::exp(complex_t{0, angle / 2});
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for collapse(2) schedule(static)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
     for (std::size_t i = 0; i < psi.data.size(); i += period) {
         for (std::size_t j = 0; j < stride; ++j) {
             psi.data[i + j] *= phase0;

--- a/qpp/sim/StateVector.hpp
+++ b/qpp/sim/StateVector.hpp
@@ -5,45 +5,70 @@
 #include <vector>
 #include <cmath>
 #include <cstddef>
+#if defined(QPP_ENABLE_OPENMP) || defined(QPP_ENABLE_GPU)
+#include <omp.h>
+#endif
 
 namespace qpp {
 namespace sim {
 
+#ifdef QPP_SINGLE_PRECISION
+using real_t = float;
+#else
+using real_t = double;
+#endif
+using complex_t = std::complex<real_t>;
+
 /// Simple state vector representation using big-endian qubit ordering.
 struct StateVector {
     /// Amplitude data in computational basis order
-    std::vector<std::complex<double>> data;
+    std::vector<complex_t> data;
     /// Number of qubits represented by the state
     std::size_t num_qubits = 0;
 
     /// Allocate space for given number of qubits and reset to |0...0>
     void allocate(std::size_t nq) {
         num_qubits = nq;
-        data.assign(std::size_t{1} << nq, {0.0, 0.0});
+        data.assign(std::size_t{1} << nq, complex_t{0.0, 0.0});
         if (!data.empty())
-            data[0] = {1.0, 0.0};
+            data[0] = complex_t{1.0, 0.0};
     }
 
     /// Normalize amplitudes so that total probability equals one
     void normalize() {
-        double norm = 0.0;
-        for (const auto &amp : data)
-            norm += std::norm(amp);
+        real_t norm = 0.0;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for reduction(+:norm)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for reduction(+:norm)
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i)
+            norm += std::norm(data[i]);
         if (norm == 0.0)
             return;
-        double inv = 1.0 / std::sqrt(norm);
-        for (auto &amp : data)
-            amp *= inv;
+        real_t inv = real_t{1.0} / std::sqrt(norm);
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i)
+            data[i] *= inv;
     }
 
     /// Probability of a specific basis state index
-    double probability(std::size_t index) const {
+    real_t probability(std::size_t index) const {
         return std::norm(data[index]);
     }
 
     /// Probabilities for all basis states
-    std::vector<double> probabilities() const {
-        std::vector<double> probs(data.size());
+    std::vector<real_t> probabilities() const {
+        std::vector<real_t> probs(data.size());
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
         for (std::size_t i = 0; i < data.size(); ++i)
             probs[i] = std::norm(data[i]);
         return probs;
@@ -53,16 +78,24 @@ struct StateVector {
     /// Qubits are specified using big-endian order (q=0 is highest bit).
     /// Returns a vector of size 2^k where k = qubits.size(), with
     /// probabilities ordered in big-endian bit order of the measured qubits.
-    std::vector<double> measure_probs(const std::vector<int> &qubits) const {
+    std::vector<real_t> measure_probs(const std::vector<int> &qubits) const {
         if (qubits.empty())
             return probabilities();
         std::size_t k = qubits.size();
-        std::vector<double> probs(std::size_t{1} << k, 0.0);
+        std::vector<real_t> probs(std::size_t{1} << k, real_t{0});
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
         for (std::size_t i = 0; i < data.size(); ++i) {
-            double p = std::norm(data[i]);
-            if (p == 0.0)
+            real_t p = std::norm(data[i]);
+            if (p == real_t{0})
                 continue;
             std::size_t outcome = 0;
+#if defined(QPP_ENABLE_OPENMP)
+#pragma omp simd
+#endif
             for (std::size_t j = 0; j < k; ++j) {
                 int q = qubits[j];
                 std::size_t bit = num_qubits - 1 - static_cast<std::size_t>(q);


### PR DESCRIPTION
## Summary
- Add precision and GPU/OpenMP flags in `StateVector` and annotate loops for parallelism
- Vectorize gate application loops and support precision toggling in `Gates.hpp`
- Introduce FFT backend selection macros for FFTW/oneMKL/cuFFT with float precision support

## Testing
- `g++ -std=c++17 -I. -Iinclude -fopenmp -DQPP_ENABLE_OPENMP /tmp/test.cpp -o /tmp/test`


------
https://chatgpt.com/codex/tasks/task_e_68be5e1aa3c4832fabc9811d4ba5995e