### PR TITLE
Add Bell state example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,25 @@ After building, you can compile the demonstration program in
 ./pbool_demo
 ```
 
+To explore the circuit API, the `examples/bell_state.cpp` program
+creates a Bell state using `Circuit` and `Program` with the
+`LocalSimBackend` and prints the resulting measurement
+probabilities:
+
+```sh
+./build/gcc/g++ -Iinclude examples/bell_state.cpp \
+    qpp/backend/LocalSimBackend.cpp -o bell_state
+./bell_state
+```
+
+Alternatively, the examples can be built using CMake:
+
+```sh
+cmake -S examples -B build/examples
+cmake --build build/examples --target bell_state
+./build/examples/bell_state
+```
+
 ### Parsing Example
 
 The repository includes a small prototype parser that emits a JSON

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.12)
+project(qpp_examples LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+add_executable(pbool_demo pbool_demo.cpp)
+add_executable(qstruct_demo qstruct_demo.cpp)
+add_executable(scheduler_demo scheduler_demo.cpp)
+add_executable(bell_state bell_state.cpp ../qpp/backend/LocalSimBackend.cpp)

--- a/examples/bell_state.cpp
+++ b/examples/bell_state.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include "qpp/api/Program.hpp"
+
+int main() {
+    qpp::api::Circuit circ;
+    circ.allocateQubits(2);
+    circ.addGate("H", {0});
+    circ.addGate("CX", {0, 1});
+    circ.addGate("measure", {0, 1});
+
+    qpp::LocalSimBackend sim;
+    qpp::api::Program prog(circ, nullptr, &sim);
+    auto result = prog.execute();
+
+    for (const auto& [bits, prob] : result.probabilities)
+        std::cout << bits << ": " << prob << '\n';
+    return 0;
+}

--- a/tests/test_qpp.py
+++ b/tests/test_qpp.py
@@ -25,6 +25,20 @@ class QppTests(unittest.TestCase):
         self.assertIn('P(a=true)=0.6', out)
         self.assertIn('P(a&&b=true)=0.42', out)
 
+    def test_bell_state_example(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            exe = Path(tmp) / 'bell'
+            subprocess.run(
+                ['g++', '-I', str(include_dir),
+                 str(root_dir / 'examples/bell_state.cpp'),
+                 str(root_dir / 'qpp/backend/LocalSimBackend.cpp'),
+                 '-o', str(exe)],
+                check=True
+            )
+            result = subprocess.run([str(exe)], capture_output=True, text=True)
+            self.assertIn('00: 0.5', result.stdout)
+            self.assertIn('11: 0.5', result.stdout)
+
     def test_scheduler_demo(self):
         out = self.compile_and_run(str(root_dir / 'examples/scheduler_demo.cpp'), 'sch')
         self.assertIn('H 0', out)


### PR DESCRIPTION
## Summary
- Add Bell state example using Circuit and Program with LocalSimBackend
- Provide CMake support and README instructions for building examples
- Test Bell state example to verify expected measurement probabilities

## Testing
- `python3 -m pytest tests/test_qpp.py`

------
https://chatgpt.com/codex/tasks/task_e_68be6257e550832fa35df5ec0197d042