### PR TITLE
Add QPU backend tests and CMake support

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(qpp_tests LANGUAGES CXX)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../qpp/backend ${CMAKE_CURRENT_BINARY_DIR}/qpp_backend)
+target_include_directories(qpp_backend PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
+
+option(QPP_ENABLE_HARDWARE_TESTS "Build tests requiring QPU backend" OFF)
+
+enable_testing()
+
+if(QPP_ENABLE_HARDWARE_TESTS)
+    add_executable(test_qpu_backend test_qpu_backend.cpp)
+    target_include_directories(test_qpu_backend PRIVATE ${CMAKE_CURRENT_LIST_DIR}/../include)
+    target_link_libraries(test_qpu_backend PRIVATE qpp_backend)
+    target_compile_definitions(test_qpu_backend PRIVATE QPP_ENABLE_QPU=1)
+    add_test(NAME qpu_backend COMMAND test_qpu_backend)
+endif()
+

--- a/tests/test_qpu_backend.cpp
+++ b/tests/test_qpu_backend.cpp
@@ -1,0 +1,94 @@
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <cmath>
+
+#include "qpp/backend/Factory.hpp"
+#include "qpp/backend/LocalSimBackend.hpp"
+#include "qpp/backend/QPUBackend.hpp"
+
+using namespace qpp;
+
+// RAII helper to manage environment variables
+class ScopedEnv {
+public:
+    ScopedEnv(const char* name, const char* value) : name_{name} {
+        const char* old = std::getenv(name);
+        if (old) {
+            had_old_ = true;
+            old_ = old;
+        }
+        setenv(name_, value, 1);
+    }
+    ~ScopedEnv() {
+        if (had_old_)
+            setenv(name_, old_.c_str(), 1);
+        else
+            unsetenv(name_);
+    }
+private:
+    const char* name_;
+    std::string old_;
+    bool had_old_ = false;
+};
+
+// Loopback backend that uses the simulator under the hood
+class LoopbackQPUBackend : public QPUBackend {
+public:
+    bool available() const override { return true; }
+    void loadCircuit(const std::string& circuit) override {
+        QPUBackend::loadCircuit(circuit);
+        sim_.loadCircuit(circuit);
+    }
+    RunResult run() override { return sim_.run(); }
+private:
+    LocalSimBackend sim_;
+};
+
+int main() {
+    // BackendFactory selects hardware when available
+    {
+        ScopedEnv env{"QPU_PCI_DEVICE", "loopback"};
+        auto backend = BackendFactory::create();
+        assert(dynamic_cast<QPUBackend*>(backend.get()) &&
+               "Factory should return QPU backend when hardware is present");
+    }
+
+    // BackendFactory falls back to simulator when no hardware is found
+    {
+        unsetenv("QPU_PCI_DEVICE");
+        auto backend = BackendFactory::create();
+        assert(dynamic_cast<LocalSimBackend*>(backend.get()) &&
+               "Factory should return simulator when no hardware is present");
+    }
+
+    // Parity tests between mock hardware and simulator
+    LoopbackQPUBackend hw;
+    LocalSimBackend sim;
+
+    // Single-qubit Hadamard
+    std::string h_circuit = "h 0; measure 0;";
+    hw.loadCircuit(h_circuit);
+    sim.loadCircuit(h_circuit);
+    RunResult hr = hw.run();
+    RunResult sr = sim.run();
+    assert(std::abs(hr.probabilities["0"] - sr.probabilities["0"]) < 1e-9);
+    assert(std::abs(hr.probabilities["1"] - sr.probabilities["1"]) < 1e-9);
+
+    // Two-qubit Grover search for state |11>
+    std::string grover =
+        "h 0; h 1; "
+        "x 0; x 1; h 1; cx 0 1; h 1; x 0; x 1; "
+        "h 0; h 1; x 0; x 1; h 1; cx 0 1; h 1; x 0; x 1; h 0; h 1; "
+        "measure 0; measure 1;";
+    hw.loadCircuit(grover);
+    sim.loadCircuit(grover);
+    hr = hw.run();
+    sr = sim.run();
+    assert(std::abs(hr.probabilities["11"] - sr.probabilities["11"]) < 1e-9);
+
+    std::cout << "ok\n";
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- Add loopback hardware test verifying `BackendFactory` selection logic
- Run Hadamard and Grover parity checks against simulator using a mock QPU backend
- Enable optional hardware tests via new `tests/CMakeLists.txt`

## Testing
- `cmake -S tests -B build/tests -DQPP_ENABLE_HARDWARE_TESTS=ON`
- `cmake --build build/tests`
- `cd build/tests && ctest`
- `pytest tests/test_qpp.py tests/test_periodicity.py tests/test_hardware_api.py`


------
https://chatgpt.com/codex/tasks/task_e_68be75f8b374832fbf597d960b2d2c50