### PR TITLE
Add QPP master demo example and test

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -30,3 +30,11 @@ QPU_PCI_DEVICE=dummy ./hardware_demo
 
 The program reports timing and throughput for the selected backend and for
 `LocalSimBackend` for comparison.
+
+## master_demo.cpp
+
+Compile and run directly:
+
+```
+g++ -std=c++17 -I include -I . examples/master_demo.cpp && ./a.out
+```

--- a/examples/master_demo.cpp
+++ b/examples/master_demo.cpp
@@ -1,0 +1,64 @@
+#include <iostream>
+#include <memory>
+#include "qpp/api/Circuit.hpp"
+#include "qpp/api/Program.hpp"
+#include "qpp/backend/LocalSimBackend.hpp"
+#include "qpp/hardware.hpp"
+#include "qpp/qregister.hpp"
+#include "qpp/cstruct.hpp"
+#include "qpp/pbool.h"
+#include "qpp/scheduler.hpp"
+#include "qpp/sim/StateVector.hpp"
+#include "qpp/sim/Gates.hpp"
+#include "qpp/sim/Grover.hpp"
+#include "qpp/sim/Characters.hpp"
+#include "qpp/sim/Encodings.hpp"
+#include "qpp/sim/PeriodFinding.hpp"
+
+class QPPDemo {
+public:
+  void run() {
+    using namespace qpp;
+    std::cout << "== API / backend ==\n";
+    api::Circuit c;
+    c.allocateQubits(2);
+    c.addGate("h", {0});
+    c.addGate("cx", {0,1});
+    c.shots = 256;
+    api::Program prog(c, std::make_unique<LocalSimBackend>());
+    auto res = prog.execute();
+    std::cout << "Bell state ";
+    for (auto& kv : res.counts) std::cout << kv.first << ":" << kv.second << " ";
+    std::cout << "\n";
+
+    std::cout << "== registers & structs ==\n";
+    qregister qreg(1);
+    qreg.data().apply_h(0);
+    pbool m = qreg.data().measure(0);
+    std::cout << "p(1)=" << m.probability() << " sample=" << static_cast<bool>(m) << "\n";
+    cclass ctmp(3); ctmp.data().bits[1] = 1;
+    cregister creg(2); creg[0] = 1;
+    std::cout << "creg[0]=" << creg[0] << " cclass[1]=" << ctmp.data().bits[1] << "\n";
+
+    std::cout << "== scheduler ==\n";
+    Scheduler sch;
+    sch.add([](){ std::cout << "low\n"; }, 1);
+    sch.add([](){ std::cout << "high\n"; }, 2);
+    sch.run();
+
+    std::cout << "== simulation algorithms ==\n";
+    sim::StateVector psi; psi.allocate(3);
+    for(int q=0;q<3;++q) sim::apply_gate(psi, sim::H, q);
+    sim::amplitude_amplification(psi, [](std::size_t i){return i==5;}, 1);
+    std::cout << "Grover p[5]=" << psi.probabilities()[5] << "\n";
+    auto primes = sim::prime_sieve_frequency(20);
+    std::cout << "primes:"; for(auto p:primes) std::cout << " " << p; std::cout << "\n";
+    sim::LFC lfc(2.0);
+    std::cout << "encode=" << lfc.encode(3.5,0.1) << " decode=" << lfc.decodeValue(lfc.freq(3.5)) << "\n";
+    std::cout << "period=" << sim::period_finding(2,7,6) << "\n";
+
+    std::cout << "hardware_available=" << hardware_available() << "\n";
+  }
+};
+
+int main() { QPPDemo demo; demo.run(); return 0; }

--- a/tests/test_master_demo.py
+++ b/tests/test_master_demo.py
@@ -1,0 +1,38 @@
+import subprocess
+import tempfile
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+INCLUDE = ROOT / "include"
+
+CODE = Path(ROOT / "examples" / "master_demo.cpp").read_text()
+
+class MasterDemoTest(unittest.TestCase):
+    def test_demo_runs(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "demo.cpp"
+            exe = Path(tmp) / "demo"
+            src.write_text(CODE)
+            subprocess.run(
+                [
+                    "g++",
+                    "-std=c++17",
+                    "-I",
+                    str(INCLUDE),
+                    "-I",
+                    str(ROOT),
+                    str(src),
+                    str(ROOT / "qpp" / "backend" / "LocalSimBackend.cpp"),
+                    "-o",
+                    str(exe),
+                ],
+                check=True,
+            )
+            out = subprocess.run([str(exe)], capture_output=True, text=True, check=True).stdout
+            self.assertIn("Bell state", out)
+            self.assertIn("Grover", out)
+            self.assertIn("primes:", out)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `master_demo.cpp` covering circuits, registers, scheduler, and algorithms
- document how to compile and run the demo in examples README
- add unit test that builds and runs the demo, checking key output phrases

## Testing
- `pytest tests/test_master_demo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf6dc5bd24832f9a4458d8c2101442