### PR TITLE
Add missing simulation headers to include tree

### DIFF
--- a/include/qpp/sim/Gates.hpp
+++ b/include/qpp/sim/Gates.hpp
@@ -1,0 +1,114 @@
+#ifndef QPP_SIM_GATES_HPP
+#define QPP_SIM_GATES_HPP
+
+#include <algorithm>
+#include <array>
+#include <complex>
+#include <cstddef>
+#include <cmath>
+#if defined(QPP_ENABLE_OPENMP) || defined(QPP_ENABLE_GPU)
+#include <omp.h>
+#endif
+
+#include "StateVector.hpp"
+
+namespace qpp {
+namespace sim {
+
+using GateMatrix = std::array<complex_t, 4>; // row-major 2x2
+
+inline const GateMatrix X{{ complex_t{0.0, 0.0}, complex_t{1.0, 0.0},
+                            complex_t{1.0, 0.0}, complex_t{0.0, 0.0} }};
+inline const GateMatrix Z{{ complex_t{1.0, 0.0}, complex_t{0.0, 0.0},
+                            complex_t{0.0, 0.0}, complex_t{-1.0, 0.0} }};
+constexpr real_t INV_SQRT2 =
+    static_cast<real_t>(0.70710678118654752440084436210485L);
+inline const GateMatrix H{{ complex_t{INV_SQRT2, 0.0}, complex_t{INV_SQRT2, 0.0},
+                            complex_t{INV_SQRT2, 0.0}, complex_t{-INV_SQRT2, 0.0} }};
+
+/// Apply arbitrary single-qubit gate matrix to qubit q.
+inline void apply_gate(StateVector &psi, const GateMatrix &U, std::size_t q) {
+    std::size_t bit = psi.num_qubits - 1 - q;
+    std::size_t stride = std::size_t{1} << bit;
+    std::size_t period = stride << 1;
+    std::size_t total = psi.data.size();
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for collapse(2) schedule(static)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
+    for (std::size_t i = 0; i < total; i += period) {
+        for (std::size_t j = 0; j < stride; ++j) {
+            auto a0 = psi.data[i + j];
+            auto a1 = psi.data[i + j + stride];
+            psi.data[i + j] = U[0] * a0 + U[1] * a1;
+            psi.data[i + j + stride] = U[2] * a0 + U[3] * a1;
+        }
+    }
+}
+
+/// Apply controlled-NOT with big-endian qubit indexing
+inline void apply_cx(StateVector &psi, std::size_t control, std::size_t target) {
+    if (control == target)
+        return;
+    std::size_t n = psi.num_qubits;
+    std::size_t cbit = n - 1 - control;
+    std::size_t tbit = n - 1 - target;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+    for (std::size_t i = 0; i < psi.data.size(); ++i) {
+        if (((i >> cbit) & 1u) && !((i >> tbit) & 1u)) {
+            std::size_t j = i | (std::size_t{1} << tbit);
+            std::swap(psi.data[i], psi.data[j]);
+        }
+    }
+}
+
+/// Apply Toffoli gate with two controls
+inline void apply_ccx(StateVector &psi, std::size_t c1, std::size_t c2, std::size_t target) {
+    if (c1 == target || c2 == target)
+        return;
+    std::size_t n = psi.num_qubits;
+    std::size_t b1 = n - 1 - c1;
+    std::size_t b2 = n - 1 - c2;
+    std::size_t bt = n - 1 - target;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+    for (std::size_t i = 0; i < psi.data.size(); ++i) {
+        if (((i >> b1) & 1u) && ((i >> b2) & 1u) && !((i >> bt) & 1u)) {
+            std::size_t j = i | (std::size_t{1} << bt);
+            std::swap(psi.data[i], psi.data[j]);
+        }
+    }
+}
+
+/// Apply rotation around Z-axis by given angle to qubit q
+inline void apply_rz(StateVector &psi, real_t angle, std::size_t q) {
+    std::size_t bit = psi.num_qubits - 1 - q;
+    std::size_t stride = std::size_t{1} << bit;
+    std::size_t period = stride << 1;
+    complex_t phase0 = std::exp(complex_t{0, -angle / 2});
+    complex_t phase1 = std::exp(complex_t{0, angle / 2});
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for collapse(2) schedule(static)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for collapse(2) schedule(static)
+#endif
+    for (std::size_t i = 0; i < psi.data.size(); i += period) {
+        for (std::size_t j = 0; j < stride; ++j) {
+            psi.data[i + j] *= phase0;
+            psi.data[i + j + stride] *= phase1;
+        }
+    }
+}
+
+} // namespace sim
+} // namespace qpp
+
+#endif // QPP_SIM_GATES_HPP

--- a/include/qpp/sim/Grover.hpp
+++ b/include/qpp/sim/Grover.hpp
@@ -1,0 +1,41 @@
+#ifndef QPP_SIM_GROVER_HPP
+#define QPP_SIM_GROVER_HPP
+
+#include <cstddef>
+#include <complex>
+#include <functional>
+
+#include "StateVector.hpp"
+
+namespace qpp {
+namespace sim {
+
+/// Perform amplitude amplification (Grover's algorithm) on a state vector.
+/// The oracle marks basis states for which the provided predicate returns true.
+inline void amplitude_amplification(StateVector &psi,
+                                   std::function<bool(std::size_t)> oracle,
+                                   int iters) {
+    std::size_t N = psi.data.size();
+    if (N == 0 || iters <= 0)
+        return;
+    for (int k = 0; k < iters; ++k) {
+        // Oracle phase flip
+        for (std::size_t i = 0; i < N; ++i) {
+            if (oracle(i))
+                psi.data[i] = -psi.data[i];
+        }
+        // Diffusion operator (reflection about uniform superposition)
+        std::complex<double> avg{0.0, 0.0};
+        for (const auto &amp : psi.data)
+            avg += amp;
+        avg /= static_cast<double>(N);
+        for (auto &amp : psi.data)
+            amp = 2.0 * avg - amp;
+    }
+    psi.normalize();
+}
+
+} // namespace sim
+} // namespace qpp
+
+#endif // QPP_SIM_GROVER_HPP

--- a/include/qpp/sim/StateVector.hpp
+++ b/include/qpp/sim/StateVector.hpp
@@ -1,0 +1,114 @@
+#ifndef QPP_SIM_STATEVECTOR_HPP
+#define QPP_SIM_STATEVECTOR_HPP
+
+#include <complex>
+#include <vector>
+#include <cmath>
+#include <cstddef>
+#if defined(QPP_ENABLE_OPENMP) || defined(QPP_ENABLE_GPU)
+#include <omp.h>
+#endif
+
+namespace qpp {
+namespace sim {
+
+#ifdef QPP_SINGLE_PRECISION
+using real_t = float;
+#else
+using real_t = double;
+#endif
+using complex_t = std::complex<real_t>;
+
+/// Simple state vector representation using big-endian qubit ordering.
+struct StateVector {
+    /// Amplitude data in computational basis order
+    std::vector<complex_t> data;
+    /// Number of qubits represented by the state
+    std::size_t num_qubits = 0;
+
+    /// Allocate space for given number of qubits and reset to |0...0>
+    void allocate(std::size_t nq) {
+        num_qubits = nq;
+        data.assign(std::size_t{1} << nq, complex_t{0.0, 0.0});
+        if (!data.empty())
+            data[0] = complex_t{1.0, 0.0};
+    }
+
+    /// Normalize amplitudes so that total probability equals one
+    void normalize() {
+        real_t norm = 0.0;
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for reduction(+:norm)
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for reduction(+:norm)
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i)
+            norm += std::norm(data[i]);
+        if (norm == 0.0)
+            return;
+        real_t inv = real_t{1.0} / std::sqrt(norm);
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i)
+            data[i] *= inv;
+    }
+
+    /// Probability of a specific basis state index
+    real_t probability(std::size_t index) const {
+        return std::norm(data[index]);
+    }
+
+    /// Probabilities for all basis states
+    std::vector<real_t> probabilities() const {
+        std::vector<real_t> probs(data.size());
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i)
+            probs[i] = std::norm(data[i]);
+        return probs;
+    }
+
+    /// Measurement probability distribution for selected qubits.
+    /// Qubits are specified using big-endian order (q=0 is highest bit).
+    /// Returns a vector of size 2^k where k = qubits.size(), with
+    /// probabilities ordered in big-endian bit order of the measured qubits.
+    std::vector<real_t> measure_probs(const std::vector<int> &qubits) const {
+        if (qubits.empty())
+            return probabilities();
+        std::size_t k = qubits.size();
+        std::vector<real_t> probs(std::size_t{1} << k, real_t{0});
+#if defined(QPP_ENABLE_GPU)
+#pragma omp target teams distribute parallel for
+#elif defined(QPP_ENABLE_OPENMP)
+#pragma omp parallel for
+#endif
+        for (std::size_t i = 0; i < data.size(); ++i) {
+            real_t p = std::norm(data[i]);
+            if (p == real_t{0})
+                continue;
+            std::size_t outcome = 0;
+#if defined(QPP_ENABLE_OPENMP)
+#pragma omp simd
+#endif
+            for (std::size_t j = 0; j < k; ++j) {
+                int q = qubits[j];
+                std::size_t bit = num_qubits - 1 - static_cast<std::size_t>(q);
+                std::size_t val = (i >> bit) & 1u;
+                outcome = (outcome << 1) | val;
+            }
+            probs[outcome] += p;
+        }
+        return probs;
+    }
+};
+
+} // namespace sim
+} // namespace qpp
+
+#endif // QPP_SIM_STATEVECTOR_HPP


### PR DESCRIPTION
## Summary
- add StateVector, Gates, and Grover headers to public include path so examples can locate them

## Testing
- `g++ -std=c++17 -Iinclude examples/master_demo.cpp qpp/backend/LocalSimBackend.cpp -o master_demo`
- `./master_demo`


------
https://chatgpt.com/codex/tasks/task_e_68c053873734832f99a3fcaeefeeb41f