### PR TITLE
docs: fix master_demo build instructions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,8 @@ The program reports timing and throughput for the selected backend and for
 
 Compile and run directly:
 
-```
-g++ -std=c++17 -I include -I . examples/master_demo.cpp && ./a.out
+```sh
+g++ -std=c++17 -I include -I . examples/master_demo.cpp \
+    qpp/backend/LocalSimBackend.cpp -o master_demo
+./master_demo
 ```


### PR DESCRIPTION
## Summary
- correct `master_demo` example command to link `LocalSimBackend`

## Testing
- `pytest -q tests/test_master_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68c06908281c832f88e41db557c8be4a