### PR TITLE
feat: configure project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,28 @@
 cmake_minimum_required(VERSION 3.20)
-project(qpp VERSION 0.1.0 LANGUAGES CXX)
+
+# Determine project version from environment or git tag, defaulting to 0.1.6
+if(DEFINED ENV{QPP_VERSION})
+  set(QPP_VERSION $ENV{QPP_VERSION})
+else()
+  execute_process(
+    COMMAND git describe --tags --abbrev=0
+    OUTPUT_VARIABLE QPP_VERSION_FROM_GIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+  if(QPP_VERSION_FROM_GIT)
+    string(REGEX REPLACE "^v" "" QPP_VERSION_FROM_GIT "${QPP_VERSION_FROM_GIT}")
+    if(QPP_VERSION_FROM_GIT MATCHES "^[0-9]+\\.[0-9]+(\\.[0-9]+)?")
+      set(QPP_VERSION ${QPP_VERSION_FROM_GIT})
+    else()
+      set(QPP_VERSION 0.1.6)
+    endif()
+  else()
+    set(QPP_VERSION 0.1.6)
+  endif()
+endif()
+
+project(qpp VERSION ${QPP_VERSION} LANGUAGES CXX)
 
 # your targets here
 add_executable(qpp src/main.cpp)  # example


### PR DESCRIPTION
## Summary
- derive project version from `QPP_VERSION` env var or git tag with a 0.1.6 fallback

## Testing
- `QPP_VERSION=0.1.6 cmake -S . -B build`
- `cmake --build build`
- `cd build && cpack`


------
https://chatgpt.com/codex/tasks/task_e_68c405f59e6c832f84449e220af828cf