### PR TITLE
Ensure macOS arm64 tarball naming and add qpp CLI help

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,4 +54,17 @@ endif()
 # Windows: leave ZIP for now; installer can come later
 # macOS: use ZIP/TGZ; Homebrew will build from tarball
 
+# Override the default system name in package file/folder names.
+# By default CPack uses values like "Darwin" which end up creating
+# archives such as qpp-0.1.6-Darwin.tar.gz.  Downstream tooling expects
+# the macOS arm64 package to contain a top-level directory named
+# "qpp-<version>-macos-arm64" instead.
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+    set(CPACK_SYSTEM_NAME "macos-arm64")
+  else()
+    set(CPACK_SYSTEM_NAME "macos-x64")
+  endif()
+endif()
+
 include(CPack)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,23 @@
-int main() {
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv) {
+    // Print a helpful message describing how to use Q++ when invoked with
+    // --help or -h.  If no arguments are given, we also show the message so
+    // users learn how to invoke the compiler.
+    if (argc < 2 || std::string(argv[1]) == "--help" || std::string(argv[1]) == "-h") {
+        std::cout << "Q++ compiler and simulator\n"
+                  << "Usage: qpp [options] <source-file.qpp>\n\n"
+                  << "Options:\n"
+                  << "  -h, --help    Show this help message and exit\n\n"
+                  << "A Q++ program is stored in a file with the extension .qpp.\n"
+                  << "Compile and run a program with:\n"
+                  << "  qpp hello.qpp\n";
+        return 0;
+    }
+
+    // Placeholder for future compiler logic.
+    // TODO: add real compilation and simulation steps here.
     return 0;
 }
+


### PR DESCRIPTION
## Summary
- Override CPack system name so macOS arm64 packages extract to `qpp-<version>-macos-arm64`
- Add a basic `--help` message to the `qpp` executable describing how to use Q++ files

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/qpp --help`
- `cpack --config build/CPackConfig.cmake`


------
https://chatgpt.com/codex/tasks/task_e_68c41211620c832fb121abe142f40dac