### PR TITLE
Add basic Q++ compiler runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 project(qpp VERSION ${QPP_VERSION} LANGUAGES CXX)
 
 # your targets here
-add_executable(qpp src/main.cpp)  # example
+add_executable(qpp src/main.cpp src/compiler.cpp)  # example
 
 # ---------- Install rules ----------
 # Binaries

--- a/README.md
+++ b/README.md
@@ -43,6 +43,32 @@ new language constructs and tooling to support quantum-aware C++ development.
 
 These features are experimental and not part of upstream GCC.
 
+## Installing a release
+
+Prebuilt binaries are published on the project's releases page. Download the
+archive matching your platform, extract it, and place the `qpp` executable on
+your `PATH`.
+
+### Linux
+
+```sh
+curl -L -o qpp.tar.gz https://github.com/<owner>/qpp-gcc/releases/download/<tag>/qpp-<tag>-linux-x86_64.tar.gz
+tar -xzf qpp.tar.gz
+sudo mv qpp-<tag>/bin/qpp /usr/local/bin/
+qpp --help
+```
+
+### macOS
+
+```sh
+curl -L -o qpp-macos.tar.gz https://github.com/<owner>/qpp-gcc/releases/download/<tag>/qpp-<tag>-macos-x86_64.tar.gz
+tar -xzf qpp-macos.tar.gz
+sudo mv qpp-<tag>/bin/qpp /usr/local/bin/
+xattr -dr com.apple.quarantine /usr/local/bin/qpp  # remove quarantine
+codesign --force --sign - /usr/local/bin/qpp       # optional ad-hoc signing
+qpp --help
+```
+
 ## Building from source
 
 The Q++ fork retains GCC's traditional `configure`/`make` build
@@ -127,24 +153,6 @@ QPP
 /usr/local/gcc-x86_64/bin/g++ -std=c++17 -x c++ helloworld.qpp -o helloworld
 ./helloworld
 ```
-
-Prebuilt macOS binaries are periodically published on the project's
-releases page. Check there if you prefer not to build from source.
-
-After downloading a release, macOS may quarantine the binary. If you see a message like "Apple cannot verify 'qpp'", remove the quarantine attribute:
-
-```sh
-xattr -dr com.apple.quarantine /usr/local/bin/qpp
-```
-
-Adjust the path if you install the binary elsewhere. You can also ad-hoc sign the binary:
-
-```sh
-codesign --force --sign - /usr/local/bin/qpp
-```
-
-After either step, run `qpp --help` to verify the installation.
-
 
 ### Example
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -1,0 +1,62 @@
+#include "compiler.hpp"
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <sstream>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path find_repo_root(fs::path start) {
+    while (!start.empty()) {
+        if (fs::exists(start / "include" / "qpp"))
+            return start;
+        auto parent = start.parent_path();
+        if (parent == start)
+            break;
+        start = parent;
+    }
+    return {};
+}
+
+std::string quote(const fs::path& p) {
+    return std::string("\"") + p.string() + "\"";
+}
+
+} // namespace
+
+int compile_and_run(const std::string& source_path) {
+    fs::path root = find_repo_root(fs::current_path());
+    if (root.empty()) {
+        std::cerr << "Could not locate repository root containing include/qpp\n";
+        return 1;
+    }
+
+    fs::path include = root / "include";
+    fs::path local_backend = root / "qpp" / "backend" / "LocalSimBackend.cpp";
+    fs::path qpu_backend = root / "qpp" / "backend" / "QPUBackend.cpp";
+
+    auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    fs::path out = fs::temp_directory_path() / ("qpp-" + std::to_string(now));
+
+    std::ostringstream cmd;
+    cmd << "g++ -std=c++17 -x c++ -I" << quote(include)
+        << " -I" << quote(root)
+        << " " << quote(fs::path(source_path))
+        << " " << quote(local_backend)
+        << " " << quote(qpu_backend)
+        << " -o " << quote(out);
+
+    if (std::system(cmd.str().c_str()) != 0) {
+        std::cerr << "Compilation failed\n";
+        return 1;
+    }
+
+    int ret = std::system(quote(out).c_str());
+    fs::remove(out);
+    return ret;
+}
+

--- a/src/compiler.hpp
+++ b/src/compiler.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string>
+
+// Compiles the given .qpp source file and executes the resulting binary.
+// Returns the exit code of the executed program, or a non-zero value on
+// failure.
+int compile_and_run(const std::string& source_path);
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <string>
 
+#include "compiler.hpp"
+
 int main(int argc, char** argv) {
     // Print a helpful message describing how to use Q++ when invoked with
     // --help or -h.  If no arguments are given, we also show the message so
@@ -16,8 +18,6 @@ int main(int argc, char** argv) {
         return 0;
     }
 
-    // Placeholder for future compiler logic.
-    // TODO: add real compilation and simulation steps here.
-    return 0;
+    return compile_and_run(argv[1]);
 }
 


### PR DESCRIPTION
## Summary
- add minimal compile-and-run driver for `.qpp` sources
- update build to include new compiler module

## Testing
- `cmake --build .`
- `./qpp ../examples/pbool_demo.qpp`
- `./qpp ../examples/hardware_api_example.qpp`
- `./qpp ../examples/bell_state.qpp`


------
https://chatgpt.com/codex/tasks/task_e_68c47e74f194832f96576aa270859c2e