### PR TITLE
Document prerequisite download step in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ system. The process below mirrors the steps outlined in
 [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 ```sh
+# Download prerequisite libraries (GMP, MPFR, MPC, etc.)
+./contrib/download_prerequisites
+
 # Create a separate build directory
 mkdir build && cd build
 


### PR DESCRIPTION
## Summary
- mention running `./contrib/download_prerequisites` to fetch GMP, MPFR, MPC before building

## Testing
- `make check` *(fails: No rule to make target 'check')*


------
https://chatgpt.com/codex/tasks/task_e_68c4b1057b6c832fa68342644d3a9e89