### PR TITLE
Add README guides for Q++ example sources

### DIFF
--- a/examples/bell_state.README.md
+++ b/examples/bell_state.README.md
@@ -1,0 +1,32 @@
+# Bell State Example
+
+## Overview
+`bell_state.qpp` builds a two-qubit circuit, entangles the qubits with a Hadamard and CNOT, and measures both qubits using the `qpp::api::Program` helper around `LocalSimBackend`.
+
+## Key Concepts Demonstrated
+- Allocating qubits, appending gates, and recording measurements through `qpp::api::Circuit`.
+- Executing the circuit on the built-in deterministic simulator and iterating over the returned probability table.
+
+## Build and Run
+### CMake (recommended)
+1. Configure and build the examples (see `examples/README.md` for full context):
+   ```sh
+   cd examples
+   mkdir -p build && cd build
+   cmake ..
+   make bell_state
+   ```
+2. Execute the sample from the build directory:
+   ```sh
+   ./bell_state
+   ```
+   The output lists measurement probabilities, e.g. `00: 0.5` and `11: 0.5` for the ideal Bell state.
+
+### Stand-alone Compilation
+Compile the `.cpp` wrapper together with the simulator implementation from the repository root:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/bell_state.cpp \
+    qpp/backend/LocalSimBackend.cpp -o bell_state
+./bell_state
+```
+The wrapper forwards to `bell_state.qpp`, so including the headers from `include/` is sufficient for the rest of the Q++ API.

--- a/examples/hardware_api_example.README.md
+++ b/examples/hardware_api_example.README.md
@@ -1,0 +1,27 @@
+# Hardware API Stub Example
+
+## Overview
+`hardware_api_example.qpp` exercises the lightweight `HardwareStub` implementation to show how Q++ code can emit Quantum Intermediate Representation (QIR) instructions before actual device connectors are available.
+
+## Walkthrough
+- Instantiate `qpp::HardwareStub` inside `main`.
+- Emit a sequence of textual operations (`H`, `CX`, and `MEASURE`) that the stub records in memory.
+- Print the buffered program to standard output so you can inspect the generated QIR payload.
+
+## Build and Run
+### CMake
+```sh
+cd examples
+mkdir -p build && cd build
+cmake ..
+make hardware_api_example
+./hardware_api_example
+```
+The program prints the collected instructions separated by newlines.
+
+### Stand-alone Compilation
+When building from the repository root, only the headers are required:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/hardware_api_example.cpp -o hardware_api_example
+./hardware_api_example
+```

--- a/examples/hardware_demo.README.md
+++ b/examples/hardware_demo.README.md
@@ -1,0 +1,28 @@
+# Hardware Backend Demo
+
+## Overview
+`hardware_demo.qpp` compares executing a simple Bell-state circuit on either a discovered hardware backend or the local simulator. It requests a backend via `QPUBackend::discoverDevices()`, falls back to `LocalSimBackend` when no device is found, and reports both execution time and throughput for the selected backend and simulator.
+
+## Execution Flow
+1. Build a two-qubit circuit with Hadamard, CNOT, and measurement, configured for 1024 shots.
+2. Inspect `QPU_PCI_DEVICE`, `QPU_USB_DEVICE`, and `QPU_NET_DEVICE` environment variables to choose a hardware device.
+3. Run the program on the chosen backend, measure wall-clock duration, then repeat with `LocalSimBackend` for comparison.
+
+## Build and Run
+### CMake
+```sh
+cd examples
+mkdir -p build && cd build
+cmake ..
+make hardware_demo
+./hardware_demo
+```
+Set one of the `QPU_*_DEVICE` variables (and optionally `QPU_AUTH_TOKEN`) to steer hardware selection. Without a device, the program automatically reports the simulator fallback.
+
+### Stand-alone Compilation
+Compile from the repository root, linking both backend implementations:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/hardware_demo.cpp \
+    qpp/backend/LocalSimBackend.cpp qpp/backend/QPUBackend.cpp -o hardware_demo
+./hardware_demo
+```

--- a/examples/pbool_demo.README.md
+++ b/examples/pbool_demo.README.md
@@ -1,0 +1,27 @@
+# pbool Demo
+
+## Overview
+`pbool_demo.qpp` demonstrates probabilistic boolean arithmetic and sampling. It composes two `pbool` values with logical AND, reports their individual and combined probabilities, and samples an outcome, falling back to a deterministic threshold if no quantum hardware is available.
+
+## Points of Interest
+- Logical operators on `pbool` multiply or otherwise combine probabilities, enabling quick reasoning about independent events.
+- `qpp::hardware_available()` checks the `QPP_HW_AVAILABLE` environment variable; when unset, sampling uses the host RNG instead of hardware.
+- Repeated RNG "glitches" are guarded against via an internal counter that throws after several suspicious draws.
+
+## Build and Run
+### CMake
+```sh
+cd examples
+mkdir -p build && cd build
+cmake ..
+make pbool_demo
+./pbool_demo
+```
+Set `QPP_HW_AVAILABLE=1` before running to exercise the hardware sampling path; omit it to see the simulator fallback message.
+
+### Stand-alone Compilation
+All required functionality is in headers, so compile the wrapper directly from the repository root:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/pbool_demo.cpp -o pbool_demo
+./pbool_demo
+```

--- a/examples/qpp_parse_example.README.md
+++ b/examples/qpp_parse_example.README.md
@@ -1,0 +1,14 @@
+# Q++ Syntax Example
+
+## Overview
+`qpp_parse_example.qpp` is a compact showcase of Q++ language constructs used by the custom GCC frontend. It exercises probabilistic storage types, hybrid task annotations, intrinsic QASM blocks, and gate-overloaded operators.
+
+## Language Features Highlighted
+- `qstruct` definitions that combine quantum (`qbit`) and classical fields in a single aggregate.
+- Automatic allocation of `qregister`/`cregister` storage for quantum and classical data.
+- Overloaded bitwise operators (`^`, `&`) mapping to entangling gates when applied to quantum operands.
+- Inline `__qasm { ... }` blocks that embed raw OpenQASM instructions for direct backend emission.
+- `task<QPU>` annotated functions that mark kernels intended for execution on hardware.
+
+## Usage Notes
+This file is intended for parser and tooling validation. It is not part of the default CMake build, and compiling it requires the extended Q++ toolchain rather than a standard C++ compiler. Treat it as a reference while writing or testing new language features.

--- a/examples/qstruct_demo.README.md
+++ b/examples/qstruct_demo.README.md
@@ -1,0 +1,26 @@
+# qstruct Demo
+
+## Overview
+`qstruct_demo.qpp` highlights the low-level `qclass` container that wraps a `qstruct` state vector. The sample initializes a single-qubit register, applies a Hadamard followed by a Pauli-X, and prints the resulting amplitudes.
+
+## Concepts Covered
+- Direct gate application on the in-memory quantum state without invoking a backend.
+- Accessing the internal amplitude vector for inspection or custom post-processing.
+
+## Build and Run
+### CMake
+```sh
+cd examples
+mkdir -p build && cd build
+cmake ..
+make qstruct_demo
+./qstruct_demo
+```
+The amplitudes printed after applying `H` then `X` illustrate how the state vector is updated in place (both |0⟩ and |1⟩ amplitudes remain at 1/√2).
+
+### Stand-alone Compilation
+The demo is header-only and can be built directly from the repository root:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/qstruct_demo.cpp -o qstruct_demo
+./qstruct_demo
+```

--- a/examples/scheduler_demo.README.md
+++ b/examples/scheduler_demo.README.md
@@ -1,0 +1,27 @@
+# Scheduler Demo
+
+## Overview
+`scheduler_demo.qpp` showcases the cooperative task scheduler that orchestrates quantum and classical work. It adds three lambda tasks, adjusts priorities, removes one task, and streams the resulting QIR instructions via a `HardwareStub` while mirroring the updates in a simulated `qregister`.
+
+## Highlights
+- `qpp::Scheduler` holds queued lambdas, each manipulating both the stub backend and an in-memory quantum register.
+- Priorities can be reassigned after submission; the example boosts the second task before execution.
+- Tasks are removable by index, allowing dynamic pruning before `run()` executes the queue.
+
+## Build and Run
+### CMake
+```sh
+cd examples
+mkdir -p build && cd build
+cmake ..
+make scheduler_demo
+./scheduler_demo
+```
+The output displays the QIR emitted by the two remaining tasks in priority order.
+
+### Stand-alone Compilation
+The implementation lives entirely in headers, so compiling the `.cpp` wrapper is sufficient from the repository root:
+```sh
+g++ -std=c++17 -Iinclude -I. examples/scheduler_demo.cpp -o scheduler_demo
+./scheduler_demo
+```


### PR DESCRIPTION
## Summary
- add dedicated README files for each .qpp example explaining the scenario and highlighted APIs
- document build and run instructions for CMake and direct compilation, including relevant environment variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c8559f4f60832fb1fed3789d6fb0ce