### PR TITLE
Add arrays and hashing classical and quantum helpers

### DIFF
--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
@@ -1,0 +1,282 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <numeric>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qstruct.hpp"
+
+namespace qpp::examples::arrays_and_hashing {
+
+// -----------------------------------------------------------------------------
+// Classical helper algorithms
+// -----------------------------------------------------------------------------
+
+/// Return true when the input contains any duplicate values.
+inline bool contains_duplicates(const std::vector<int>& nums) {
+    std::unordered_set<int> seen;
+    seen.reserve(nums.size());
+    for (int value : nums) {
+        if (!seen.insert(value).second)
+            return true;
+    }
+    return false;
+}
+
+/// Check whether two strings are anagrams of one another.
+inline bool valid_anagram(std::string_view s, std::string_view t) {
+    if (s.size() != t.size())
+        return false;
+
+    std::array<int, 256> counts{};
+    for (unsigned char ch : s)
+        ++counts[ch];
+    for (unsigned char ch : t) {
+        if (--counts[ch] < 0)
+            return false;
+    }
+    return true;
+}
+
+/// Return the indices of two numbers that sum to the target.
+inline std::pair<int, int> two_sum(const std::vector<int>& nums, int target) {
+    std::unordered_map<int, int> index_by_value;
+    index_by_value.reserve(nums.size());
+
+    for (std::size_t i = 0; i < nums.size(); ++i) {
+        int complement = target - nums[i];
+        auto it = index_by_value.find(complement);
+        if (it != index_by_value.end())
+            return {it->second, static_cast<int>(i)};
+        index_by_value[nums[i]] = static_cast<int>(i);
+    }
+    return {-1, -1};
+}
+
+/// Group words that are anagrams of each other.
+inline std::vector<std::vector<std::string>>
+    group_anagrams(const std::vector<std::string>& strs) {
+    std::unordered_map<std::string, std::vector<std::string>> groups;
+    for (const auto& word : strs) {
+        std::array<int, 256> counts{};
+        for (unsigned char ch : word)
+            ++counts[ch];
+        std::string signature;
+        signature.reserve(256 * 2);
+        for (int c : counts) {
+            signature.push_back('#');
+            signature.append(std::to_string(c));
+        }
+        groups[signature].push_back(word);
+    }
+
+    std::vector<std::vector<std::string>> result;
+    result.reserve(groups.size());
+    for (auto& entry : groups)
+        result.push_back(std::move(entry.second));
+    return result;
+}
+
+/// Return the k most frequent numbers.
+inline std::vector<int> top_k_frequent(const std::vector<int>& nums,
+                                       std::size_t k) {
+    std::unordered_map<int, std::size_t> frequency;
+    frequency.reserve(nums.size());
+    for (int value : nums)
+        ++frequency[value];
+
+    std::vector<std::vector<int>> buckets(nums.size() + 1);
+    for (const auto& [value, count] : frequency)
+        buckets[count].push_back(value);
+
+    std::vector<int> result;
+    result.reserve(std::min<std::size_t>(k, frequency.size()));
+    for (std::size_t count = buckets.size(); count-- > 0 && result.size() < k;) {
+        for (int value : buckets[count]) {
+            result.push_back(value);
+            if (result.size() == k)
+                break;
+        }
+    }
+    return result;
+}
+
+/// Encode a sequence of strings into a single string.
+inline std::string encode(const std::vector<std::string>& strs) {
+    std::string encoded;
+    for (const auto& s : strs) {
+        encoded.append(std::to_string(s.size()));
+        encoded.push_back('#');
+        encoded.append(s);
+    }
+    return encoded;
+}
+
+/// Decode the encoded string produced by ::encode.
+inline std::vector<std::string> decode(const std::string& data) {
+    std::vector<std::string> result;
+    std::size_t pos = 0;
+    while (pos < data.size()) {
+        std::size_t hash_pos = data.find('#', pos);
+        if (hash_pos == std::string::npos)
+            throw std::invalid_argument("Corrupted encoding: missing separator");
+
+        std::size_t length = 0;
+        for (std::size_t i = pos; i < hash_pos; ++i) {
+            if (data[i] < '0' || data[i] > '9')
+                throw std::invalid_argument("Corrupted encoding: non-digit length");
+            length = length * 10 + static_cast<std::size_t>(data[i] - '0');
+        }
+        pos = hash_pos + 1;
+        if (pos + length > data.size())
+            throw std::invalid_argument("Corrupted encoding: truncated payload");
+
+        result.emplace_back(data.substr(pos, length));
+        pos += length;
+    }
+    return result;
+}
+
+/// Compute the product of all numbers except the one at each index.
+inline std::vector<int> product_except_self(const std::vector<int>& nums) {
+    const std::size_t n = nums.size();
+    if (n == 0)
+        return {};
+
+    std::vector<int> result(n, 1);
+    int prefix = 1;
+    for (std::size_t i = 0; i < n; ++i) {
+        result[i] = prefix;
+        prefix *= nums[i];
+    }
+
+    int suffix = 1;
+    for (std::size_t i = n; i-- > 0;) {
+        result[i] *= suffix;
+        suffix *= nums[i];
+    }
+    return result;
+}
+
+/// Length of the longest consecutive integer sequence in the input.
+inline int longest_consecutive(const std::vector<int>& nums) {
+    std::unordered_set<int> values(nums.begin(), nums.end());
+    int best = 0;
+    for (int value : values) {
+        if (!values.count(value - 1)) {
+            int length = 1;
+            int current = value;
+            while (values.count(current + 1)) {
+                ++current;
+                ++length;
+            }
+            best = std::max(best, length);
+        }
+    }
+    return best;
+}
+
+// -----------------------------------------------------------------------------
+// Quantum-flavoured helpers modelling the narrative described in the example.
+// -----------------------------------------------------------------------------
+
+/// Build a register of classical bits represented as qubits in the |0> or |1>
+/// basis states. The helper returns a qclass for further manipulation while the
+/// internal qpp::pbool communicates whether the logical length carries any
+/// probabilistic interpretation (for the classical array the answer is "no").
+inline qpp::qclass make_bit_register(const std::vector<int>& bits) {
+    qpp::qclass reg(bits.size());
+    const qpp::pbool length_is_fractional(bits.empty() ? 0.0 : 1.0);
+    if (length_is_fractional.probability() == 0.0)
+        return reg;
+
+    for (std::size_t i = 0; i < bits.size(); ++i)
+        if (bits[i] != 0)
+            reg.apply_x(i);
+    return reg;
+}
+
+/// Create a register where each qubit encodes a rotation defined by the input
+/// angles. The routine multiplies the deterministic tensor-product state by a
+/// smooth weighting derived from qpp::pbool objects to mirror the "probabilistic
+/// length/index" idea from the narrative. The final state is renormalised so it
+/// can be safely consumed by later simulations.
+inline qpp::qclass make_qubit_register(const std::vector<double>& angles) {
+    qpp::qclass reg(angles.size());
+    auto& amplitude = reg.data().amplitude;
+    if (angles.empty())
+        return reg;
+
+    std::vector<double> cos_half;
+    std::vector<double> sin_half;
+    std::vector<qpp::pbool> index_bias;
+    cos_half.reserve(angles.size());
+    sin_half.reserve(angles.size());
+    index_bias.reserve(angles.size());
+
+    const double two_pi = 2.0 * std::acos(-1.0);
+    for (double angle : angles) {
+        const double half = angle / 2.0;
+        cos_half.push_back(std::cos(half));
+        sin_half.push_back(std::sin(half));
+        const double wrapped = std::fmod(std::fabs(angle), two_pi);
+        index_bias.emplace_back(qpp::pbool(wrapped / two_pi));
+    }
+
+    const double weighting = std::accumulate(
+        index_bias.begin(), index_bias.end(), 1.0,
+        [](double acc, const qpp::pbool& bias) {
+            return acc * (0.5 + bias.probability() / 2.0);
+        });
+
+    for (auto& amp : amplitude)
+        amp = {0.0, 0.0};
+
+    for (std::size_t basis = 0; basis < amplitude.size(); ++basis) {
+        double magnitude = 1.0;
+        for (std::size_t qubit = 0; qubit < angles.size(); ++qubit) {
+            const bool is_one = ((basis >> qubit) & 1u) != 0u;
+            magnitude *= is_one ? sin_half[qubit] : cos_half[qubit];
+        }
+        amplitude[basis] = {magnitude * weighting, 0.0};
+    }
+
+    double norm = 0.0;
+    for (const auto& amp : amplitude)
+        norm += std::norm(amp);
+    if (norm > 0.0) {
+        const double inv_norm = 1.0 / std::sqrt(norm);
+        for (auto& amp : amplitude)
+            amp *= inv_norm;
+    }
+    return reg;
+}
+
+/// Build two entangled two-qubit states capturing the "key-value" and
+/// "value-key" Bell-pair hashing analogy used in the documentation.
+inline std::array<qpp::qstruct, 2> make_entangled_key_value_pair() {
+    qpp::qclass direct(2);
+    direct.apply_h(0);
+    direct.apply_cx(0, 1);
+
+    qpp::qclass cross = direct;
+    cross.apply_x(1);
+
+    [[maybe_unused]] const qpp::pbool key_probability = direct.measure(0);
+    [[maybe_unused]] const qpp::pbool value_probability = direct.measure(1);
+
+    return {direct.data(), cross.data()};
+}
+
+} // namespace qpp::examples::arrays_and_hashing
+

--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
@@ -1,79 +1,212 @@
-// 1. Contains Duplicates
-// Given an integer array nums, return true if any value appears more than once in the array, otherwise return false.
+#include <array>
+#include <cmath>
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
 
-// 2. Valid Anagram  
-// Given two strings s and t, return true if the two strings are anagrams of each other, otherwise return false.
-// An anagram is a string that contains the exact same characters as another string, but the order of the characters can be different.
+#include "arrays_and_hashing.hpp"
 
-// 3. Two Sum 
-// Given an array of integers nums and an integer target, return the indices i and j such that nums[i] + nums[j] == target and i != j.
-// You may assume that every input has exactly one pair of indices i and j that satisfy the condition.
-// Return the answer with the smaller index first.
+namespace {
+std::string basis_string(std::size_t index, std::size_t qubits) {
+    std::string bits(qubits, '0');
+    for (std::size_t q = 0; q < qubits; ++q)
+        bits[qubits - q - 1] = ((index >> q) & 1u) ? '1' : '0';
+    return bits;
+}
 
-// 4. Group Anagrams
-// Given an array of strings strs, group all the anagrams together into sublists. You may return the output in any order.
-// An anagram is a string that contains the same characters as another string, but the order of the characters can be different.
+void print_state(const qpp::qstruct& state, const std::string& label) {
+    const std::size_t qubits = state.qubits();
+    std::cout << label << " (" << qubits << " qubits) amplitudes:\n";
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const double probability = std::norm(state.amplitude[i]);
+        if (probability < 1e-9)
+            continue;
+        std::cout << "  |" << basis_string(i, qubits) << "> -> "
+                  << state.amplitude[i] << " (p=" << probability << ")\n";
+    }
+}
 
-// 5. Top K frequent Elements 
-// Given an integer array nums and an integer k, return the k most frequent elements within the array.
-// The test cases are generated such that the answer is always unique.
-// You may return the output in any order.
+void demonstrate_entanglement(const qpp::qstruct& state,
+                              const std::string& label) {
+    print_state(state, label);
 
-// 6. Encode & Decode String
-// Design an algorithm to encode a list of strings into a single string. The encoded string is then decoded back to the original list of strings.
-// Please implement encode and decode
+    double prob_key_one = 0.0;
+    double prob_key_zero = 0.0;
+    double prob_value_one = 0.0;
+    double prob_value_zero = 0.0;
+    double key0_value1 = 0.0;
+    double key1_value1 = 0.0;
+    double value0_key1 = 0.0;
+    double value1_key1 = 0.0;
 
-// 7. Product of Array Except Self 
-// Given an integer array nums, return an array output where output[i] is the product of all the elements of nums except nums[i].
-// Each product is guaranteed to fit in a 32-bit integer.
-// Follow-up: Could you solve it in O(n) time without using the division operation?
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const bool key_bit = (i & 1u) != 0u;
+        const bool value_bit = ((i >> 1) & 1u) != 0u;
+        const double probability = std::norm(state.amplitude[i]);
+        if (key_bit)
+            prob_key_one += probability;
+        else
+            prob_key_zero += probability;
+        if (value_bit)
+            prob_value_one += probability;
+        else
+            prob_value_zero += probability;
+        if (!key_bit && value_bit)
+            key0_value1 += probability;
+        if (key_bit && value_bit)
+            key1_value1 += probability;
+        if (!value_bit && key_bit)
+            value0_key1 += probability;
+        if (value_bit && key_bit)
+            value1_key1 += probability;
+    }
 
-// 8. Longest Consecutive Sequence
-// Given an array of integers nums, return the length of the longest consecutive sequence of elements that can be formed.
-// A consecutive sequence is a sequence of elements in which each element is exactly 1 greater than the previous element. The elements do not have to be consecutive in the original array.
-// You must write an algorithm that runs in O(n) time.
+    const qpp::pbool key_bias(prob_key_one);
+    const qpp::pbool value_bias(prob_value_one);
+    const double value_given_key0 =
+        prob_key_zero > 0.0 ? key0_value1 / prob_key_zero : 0.0;
+    const double value_given_key1 =
+        prob_key_one > 0.0 ? key1_value1 / prob_key_one : 0.0;
+    const double key_given_value0 =
+        prob_value_zero > 0.0 ? value0_key1 / prob_value_zero : 0.0;
+    const double key_given_value1 =
+        prob_value_one > 0.0 ? value1_key1 / prob_value_one : 0.0;
 
+    std::cout << "  P(key=1) = " << key_bias.probability()
+              << ", P(value=1) = " << value_bias.probability() << '\n';
+    std::cout << "  P(value=1 | key=0) = " << value_given_key0
+              << ", P(value=1 | key=1) = " << value_given_key1 << '\n';
+    std::cout << "  P(key=1 | value=0) = " << key_given_value0
+              << ", P(key=1 | value=1) = " << key_given_value1 << "\n\n";
+}
+} // namespace
 
+int main() {
+    using namespace qpp::examples::arrays_and_hashing;
 
+    std::cout << std::boolalpha;
 
-// building an arrays from bits and o qbits
+    // Classical demonstrations
+    const std::vector<int> duplicate_input{1, 2, 3, 1};
+    std::cout << "contains_duplicates([1,2,3,1]) -> "
+              << contains_duplicates(duplicate_input) << '\n';
 
-// 0=0 -=90 1=180 +=270
+    std::cout << "valid_anagram('listen','silent') -> "
+              << valid_anagram("listen", "silent") << '\n';
 
-// [b,b,b,b] = [1|0, 1|0, 1|0, 1|0, ...] = [+|-, +|-, +|-, +|-, ...] =discrete/digital/ 0 or 180 / 100% - (100% to 0%) = 0% to 100%
+    const std::pair<int, int> sum_indices = two_sum({2, 7, 11, 15}, 9);
+    std::cout << "two_sum([2,7,11,15], 9) -> (" << sum_indices.first << ", "
+              << sum_indices.second << ")\n";
 
-// [q,q,q,q] = [1/0, 1/0, 1/0, 1/0, ...] = [+/-, +/-, +/-, +/-, ...] = continous/analog/ 0 to 360 / (0% to 100%) - (100% to 0%) = -100%(left 1) to -50%(-) to 0%(0) to 50%(+) to 100%(right 1) 
+    const std::vector<std::string> words{"eat", "tea", "tan", "ate", "nat",
+                                          "bat"};
+    const auto grouped = group_anagrams(words);
+    std::cout << "group_anagrams(['eat','tea','tan','ate','nat','bat']) ->\n";
+    for (const auto& bucket : grouped) {
+        std::cout << "  [";
+        for (std::size_t i = 0; i < bucket.size(); ++i) {
+            if (i)
+                std::cout << ", ";
+            std::cout << bucket[i];
+        }
+        std::cout << "]\n";
+    }
 
-// [b,q,b,q] = [1|0, 1/0, 1|0, 1/0, ...] = [+|-, +/-, +|-, +/-, ...] = [discrete, continous, discrete, continous]
+    const std::vector<int> freq_input{1, 1, 1, 2, 2, 3};
+    const auto top_two = top_k_frequent(freq_input, 2);
+    std::cout << "top_k_frequent([1,1,1,2,2,3], 2) -> [";
+    for (std::size_t i = 0; i < top_two.size(); ++i) {
+        if (i)
+            std::cout << ", ";
+        std::cout << top_two[i];
+    }
+    std::cout << "]\n";
 
-// length = capcity (deterministic), size (continous [probabilistic percentage full]),  index (continous [probabilistic percentage full])
+    const std::vector<std::string> message{"qpp", "arrays", "hashing"};
+    const std::string encoded = encode(message);
+    const auto decoded = decode(encoded);
+    std::cout << "encode(['qpp','arrays','hashing']) -> '" << encoded << "'\n";
+    std::cout << "decode(above) -> [";
+    for (std::size_t i = 0; i < decoded.size(); ++i) {
+        if (i)
+            std::cout << ", ";
+        std::cout << decoded[i];
+    }
+    std::cout << "]\n";
 
-// Both the data and storage size of data is probabilisticly continous but capicty is decrete and limited by real world storage constraints. 
-// to make it  probabilisticly continouswould require inifte space or percentage sized blocks storage units with discrete abstract capcity (1 unit size)  
+    const std::vector<int> products_input{1, 2, 3, 4};
+    const auto products = product_except_self(products_input);
+    std::cout << "product_except_self([1,2,3,4]) -> [";
+    for (std::size_t i = 0; i < products.size(); ++i) {
+        if (i)
+            std::cout << ", ";
+        std::cout << products[i];
+    }
+    std::cout << "]\n";
 
-// entanglement hashing 
-// bell states
-// 11 + 00
-// 10 + 01
-// 01 + 10
-// 00 + 11
+    const std::vector<int> sequence_input{100, 4, 200, 1, 3, 2};
+    std::cout << "longest_consecutive([100,4,200,1,3,2]) -> "
+              << longest_consecutive(sequence_input) << "\n\n";
 
-// Key + value pairs (if you knew the key its counterpart is its value )  
-// 11 + 00
-// 00 + 11
+    // Quantum-flavoured demonstrations
+    const std::vector<int> bit_pattern{1, 0, 1, 1};
+    qpp::qclass bit_register = make_bit_register(bit_pattern);
+    print_state(bit_register.data(), "Classical bit register");
+    std::cout << '\n';
 
-// key-value + value-key pairs (you can search a key to find its value or search a value to find its key)
-// 10 + 01
-// 01 + 10
+    const double pi = std::acos(-1.0);
+    const std::vector<double> qubit_angles{0.0, pi / 3.0, pi / 2.0};
+    qpp::qclass qubit_register = make_qubit_register(qubit_angles);
+    print_state(qubit_register.data(), "Analog qubit register");
+    std::cout << '\n';
 
-// entangled hashmap
-// key = value (11 + 00) or value = key (00 + 11)
-// call key to get value (10 + 01) or call value to get key (01 + 10)
+    // Hybrid [b, q, b, q] register built from helper outputs
+    const std::vector<int> hybrid_bits{1, 0};
+    const std::vector<double> hybrid_angles{pi / 4.0, pi / 2.5};
+    qpp::qclass bit0 = make_bit_register({hybrid_bits[0]});
+    qpp::qclass bit1 = make_bit_register({hybrid_bits[1]});
+    qpp::qclass qubit0 = make_qubit_register({hybrid_angles[0]});
+    qpp::qclass qubit1 = make_qubit_register({hybrid_angles[1]});
 
-// key = 01 + 10
-// value = 10 + 01
-// hashmap = 11 (key <-> value) = 11 ((01 + 10) <-> (10 + 01))
+    qpp::qclass hybrid(4);
+    auto& hybrid_state = hybrid.data().amplitude;
+    std::array<std::array<std::complex<double>, 2>, 4> contributions{};
+    contributions[0] = {bit0.data().amplitude[0], bit0.data().amplitude[1]};
+    contributions[1] = {qubit0.data().amplitude[0], qubit0.data().amplitude[1]};
+    contributions[2] = {bit1.data().amplitude[0], bit1.data().amplitude[1]};
+    contributions[3] = {qubit1.data().amplitude[0], qubit1.data().amplitude[1]};
 
-// hashmap[key] = 11(01 + 10) = (1101 + 1110 <-> 1110 + 1101) = 11(10 + 01) = hashmap[value] -> 10 + 01 = value
-// hashmap[value] = 11(10 + 01) = (1110 + 1101 <-> 1101 + 1110) = 11(01 + 10) = hashmap[key] -> 01 + 10 = key
+    for (auto& amp : hybrid_state)
+        amp = {0.0, 0.0};
 
+    for (std::size_t basis = 0; basis < hybrid_state.size(); ++basis) {
+        std::complex<double> amplitude(1.0, 0.0);
+        amplitude *= contributions[0][(basis >> 0) & 1u];
+        amplitude *= contributions[1][(basis >> 1) & 1u];
+        amplitude *= contributions[2][(basis >> 2) & 1u];
+        amplitude *= contributions[3][(basis >> 3) & 1u];
+        hybrid_state[basis] = amplitude;
+    }
+
+    double hybrid_norm = 0.0;
+    for (const auto& amp : hybrid_state)
+        hybrid_norm += std::norm(amp);
+    if (hybrid_norm > 0.0) {
+        const double inv = 1.0 / std::sqrt(hybrid_norm);
+        for (auto& amp : hybrid_state)
+            amp *= inv;
+    }
+
+    print_state(hybrid.data(), "Hybrid [b,q,b,q] register");
+    std::cout << '\n';
+
+    // Entangled hashing demonstration
+    const auto entangled_states = make_entangled_key_value_pair();
+    demonstrate_entanglement(entangled_states[0], "Bell pair |key=value>");
+    demonstrate_entanglement(entangled_states[1],
+                             "Bell pair |key<->value>");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement classical array and hashing helpers together with quantum register utilities in `arrays_and_hashing.hpp`
- rewrite the arrays-and-hashing example program to exercise the helper algorithms and demonstrate hybrid quantum-classical states

## Testing
- `g++ -std=c++17 -x c++ examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp -Iinclude -Iexamples/data-structures-and-algorithms/arrays-and-hashing -o arrays_and_hashing_example`
- `./arrays_and_hashing_example`


------
https://chatgpt.com/codex/tasks/task_e_68c9a4c5b1e8832fb505818b4b7fed3f