### PR TITLE
Add qpp container aliases for quantum duplicate check

### DIFF
--- a/include/qpp/entangled_set
+++ b/include/qpp/entangled_set
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <functional>
+#include <unordered_set>
+
+namespace std {
+
+/**
+ * @brief A convenience alias representing a hash set of entangled items.
+ *
+ * The alias forwards directly to `std::unordered_set`, providing an intuitive
+ * name for collections that conceptually track entangled quantum states while
+ * retaining the full interface of an unordered set.
+ */
+template <typename Key,
+          typename Hash = std::hash<Key>,
+          typename KeyEqual = std::equal_to<Key>,
+          typename Allocator = std::allocator<Key>>
+using entangled_set = std::unordered_set<Key, Hash, KeyEqual, Allocator>;
+
+} // namespace std
+

--- a/include/qpp/qint
+++ b/include/qpp/qint
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @brief Quantum integer type alias.
+ *
+ * This type alias is provided to allow quantum-oriented code to refer to a
+ * dedicated integral type while still leveraging the standard 64-bit integer
+ * implementation.  Using a fixed-width signed integer ensures deterministic
+ * behaviour across platforms.
+ */
+using qint = std::int64_t;
+

--- a/include/qpp/qvector
+++ b/include/qpp/qvector
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <vector>
+
+namespace std {
+
+/**
+ * @brief Alias exposing the standard dynamic array as a quantum vector.
+ *
+ * Providing this alias allows quantum-specific code to reference a qvector
+ * while reusing the optimised implementation of `std::vector` and its
+ * allocator-aware interface.
+ */
+template <typename T, typename Allocator = std::allocator<T>>
+using qvector = std::vector<T, Allocator>;
+
+} // namespace std
+


### PR DESCRIPTION
## Summary
- add a quantum integer alias backed by `std::int64_t`
- provide an `entangled_set` alias to `std::unordered_set`
- expose `qvector` as an alias to `std::vector`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cad8c78c40832fb6ede667415464e0