### PR TITLE
Add worlds library, application, and unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,12 +27,34 @@ project(qpp VERSION ${QPP_VERSION} LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+enable_testing()
+
+# Core library containing the quantum worlds implementation
+add_library(worlds_lib qpp/quantum_worlds.cpp)
+target_include_directories(worlds_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Lightweight testing framework used by unit tests
+add_library(testing_framework STATIC tests/testing_framework.cpp)
+target_include_directories(testing_framework PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+
 # your targets here
 add_executable(qpp src/main.cpp src/compiler.cpp)  # example
 
+add_executable(world_picker apps/world_picker/main.cpp)
+target_link_libraries(world_picker PRIVATE worlds_lib)
+
+add_executable(worlds_tests tests/worlds_tests.cpp)
+target_link_libraries(worlds_tests PRIVATE worlds_lib testing_framework)
+
+add_test(NAME worlds_tests COMMAND worlds_tests)
+
 # ---------- Install rules ----------
 # Binaries
-install(TARGETS qpp RUNTIME DESTINATION bin)
+install(TARGETS qpp world_picker RUNTIME DESTINATION bin)
+install(TARGETS worlds_lib
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin)
 # Headers (if any installable API)
 # install(DIRECTORY include/ DESTINATION include)
 

--- a/tests/testing_framework.cpp
+++ b/tests/testing_framework.cpp
@@ -1,0 +1,106 @@
+#include "testing_framework.hpp"
+
+#include <cmath>
+#include <exception>
+#include <iostream>
+#include <mutex>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace qpp::test {
+
+namespace {
+std::vector<TestCase> &registry() {
+    static std::vector<TestCase> tests;
+    return tests;
+}
+
+std::mutex &registry_mutex() {
+    static std::mutex mtx;
+    return mtx;
+}
+} // namespace
+
+ExpectationFailure::ExpectationFailure(std::string message)
+    : std::runtime_error(std::move(message)) {}
+
+void register_test(std::string name, TestFunc func) {
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    registry().push_back(TestCase{std::move(name), std::move(func)});
+}
+
+TestRegistration::TestRegistration(const char *name, TestFunc func) {
+    register_test(name, std::move(func));
+}
+
+void expect(bool condition, const char *expression, const char *file, int line) {
+    if (!condition) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expectation failed: " << expression;
+        throw ExpectationFailure(oss.str());
+    }
+}
+
+void expect_near(double lhs, double rhs, double tolerance, const char *lhs_expr,
+                 const char *rhs_expr, const char *file, int line) {
+    if (tolerance < 0.0) {
+        std::ostringstream oss;
+        oss << file << ':' << line
+            << ": tolerance must be non-negative for expectation involving " << lhs_expr
+            << " and " << rhs_expr;
+        throw ExpectationFailure(oss.str());
+    }
+    if (std::fabs(lhs - rhs) > tolerance) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expected " << lhs_expr << " ≈ " << rhs_expr
+            << " within " << tolerance << " but difference was " << std::fabs(lhs - rhs);
+        throw ExpectationFailure(oss.str());
+    }
+}
+
+int run_all_tests() {
+    std::vector<TestCase> tests_copy;
+    {
+        std::lock_guard<std::mutex> lock(registry_mutex());
+        tests_copy = registry();
+    }
+
+    std::size_t total = tests_copy.size();
+    std::size_t failed = 0;
+
+    std::cout << "[==========] Running " << total << " test(s)." << std::endl;
+
+    for (const auto &test : tests_copy) {
+        std::cout << "[ RUN      ] " << test.name << std::endl;
+        try {
+            test.func();
+            std::cout << "[       OK ] " << test.name << std::endl;
+        } catch (const ExpectationFailure &e) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.name << std::endl;
+            std::cerr << "  " << e.what() << std::endl;
+        } catch (const std::exception &e) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.name << std::endl;
+            std::cerr << "  unexpected exception: " << e.what() << std::endl;
+        } catch (...) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.name << std::endl;
+            std::cerr << "  unknown exception" << std::endl;
+        }
+    }
+
+    std::cout << "[==========] " << total << " test(s) ran." << std::endl;
+    std::cout << "[  PASSED  ] " << (total - failed) << " test(s)." << std::endl;
+    if (failed != 0) {
+        std::cout << "[  FAILED  ] " << failed << " test(s)." << std::endl;
+    }
+
+    return failed == 0 ? 0 : 1;
+}
+
+} // namespace qpp::test
+
+int main() { return qpp::test::run_all_tests(); }
+

--- a/tests/testing_framework.hpp
+++ b/tests/testing_framework.hpp
@@ -1,0 +1,99 @@
+#pragma once
+
+#include <functional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <typeinfo>
+
+namespace qpp::test {
+
+using TestFunc = std::function<void()>;
+
+struct TestCase {
+    std::string name;
+    TestFunc func;
+};
+
+class ExpectationFailure : public std::runtime_error {
+  public:
+    explicit ExpectationFailure(std::string message);
+};
+
+void register_test(std::string name, TestFunc func);
+void expect(bool condition, const char *expression, const char *file, int line);
+void expect_near(double lhs, double rhs, double tolerance, const char *lhs_expr,
+                 const char *rhs_expr, const char *file, int line);
+
+template <typename LHS, typename RHS>
+void expect_equal(const LHS &lhs, const RHS &rhs, const char *lhs_expr,
+                  const char *rhs_expr, const char *file, int line) {
+    if (!(lhs == rhs)) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expected " << lhs_expr << " == " << rhs_expr;
+        throw ExpectationFailure(oss.str());
+    }
+}
+
+template <typename LHS, typename RHS>
+void expect_not_equal(const LHS &lhs, const RHS &rhs, const char *lhs_expr,
+                      const char *rhs_expr, const char *file, int line) {
+    if (lhs == rhs) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expected " << lhs_expr << " != " << rhs_expr;
+        throw ExpectationFailure(oss.str());
+    }
+}
+
+template <typename Exception, typename Callable>
+void expect_throw(Callable &&callable, const char *expression, const char *file,
+                  int line) {
+    try {
+        callable();
+    } catch (const Exception &) {
+        return;
+    } catch (const std::exception &e) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expected " << expression << " to throw "
+            << typeid(Exception).name() << " but caught " << typeid(e).name()
+            << " (" << e.what() << ')';
+        throw ExpectationFailure(oss.str());
+    } catch (...) {
+        std::ostringstream oss;
+        oss << file << ':' << line << ": expected " << expression << " to throw "
+            << typeid(Exception).name() << " but caught an unknown exception";
+        throw ExpectationFailure(oss.str());
+    }
+    std::ostringstream oss;
+    oss << file << ':' << line << ": expected " << expression << " to throw "
+        << typeid(Exception).name() << " but no exception was thrown";
+    throw ExpectationFailure(oss.str());
+}
+
+class TestRegistration {
+  public:
+    TestRegistration(const char *name, TestFunc func);
+};
+
+int run_all_tests();
+
+} // namespace qpp::test
+
+#define QPP_TEST(name)                                                                \
+    static void name();                                                               \
+    static ::qpp::test::TestRegistration name##_registration{#name, &name};           \
+    static void name()
+
+#define QPP_EXPECT(expr) ::qpp::test::expect((expr), #expr, __FILE__, __LINE__)
+#define QPP_EXPECT_TRUE(expr) QPP_EXPECT(expr)
+#define QPP_EXPECT_FALSE(expr)                                                        \
+    ::qpp::test::expect(!(expr), "!(" #expr ")", __FILE__, __LINE__)
+#define QPP_EXPECT_EQ(lhs, rhs)                                                       \
+    ::qpp::test::expect_equal((lhs), (rhs), #lhs, #rhs, __FILE__, __LINE__)
+#define QPP_EXPECT_NE(lhs, rhs)                                                       \
+    ::qpp::test::expect_not_equal((lhs), (rhs), #lhs, #rhs, __FILE__, __LINE__)
+#define QPP_EXPECT_NEAR(lhs, rhs, tol)                                                \
+    ::qpp::test::expect_near((lhs), (rhs), (tol), #lhs, #rhs, __FILE__, __LINE__)
+#define QPP_EXPECT_THROW(expr, exception_type)                                        \
+    ::qpp::test::expect_throw<exception_type>([&]() { expr; }, #expr, __FILE__, __LINE__)
+

--- a/tests/worlds_tests.cpp
+++ b/tests/worlds_tests.cpp
@@ -1,0 +1,94 @@
+#include "testing_framework.hpp"
+
+#include "qpp/quantum_worlds.hpp"
+
+#include <numeric>
+#include <stdexcept>
+#include <vector>
+
+using qpp::quantum::BackendKind;
+using qpp::quantum::FactorRegistry;
+using qpp::quantum::WorldSignature;
+
+QPP_TEST(ParseBackendRecognizesNames) {
+    QPP_EXPECT_EQ(qpp::quantum::parse_backend("cpu"), BackendKind::CPU);
+    QPP_EXPECT_EQ(qpp::quantum::parse_backend("QPU"), BackendKind::QPU_SIM);
+    QPP_EXPECT_EQ(qpp::quantum::parse_backend("qpu_sim"), BackendKind::QPU_SIM);
+    QPP_EXPECT_THROW(qpp::quantum::parse_backend("invalid"), std::invalid_argument);
+}
+
+QPP_TEST(FactorRegistryAssignsUniquePrimes) {
+    FactorRegistry registry;
+    auto cat = registry.register_factor("cat");
+    auto hat = registry.register_factor("hat");
+    QPP_EXPECT_NE(cat, hat);
+    QPP_EXPECT_EQ(registry.prime_of("cat"), cat);
+    QPP_EXPECT_TRUE(registry.contains("hat"));
+    QPP_EXPECT_EQ(registry.size(), static_cast<std::size_t>(2));
+    registry.clear();
+    QPP_EXPECT_EQ(registry.size(), static_cast<std::size_t>(0));
+}
+
+QPP_TEST(WorldSignatureSorting) {
+    WorldSignature signature;
+    signature.add_factor("beta", 0.5);
+    signature.add_factor("alpha", 1.0);
+    signature.sort();
+    QPP_EXPECT_EQ(signature.factors.front().first, "alpha");
+    QPP_EXPECT_EQ(signature.factors.back().first, "beta");
+}
+
+QPP_TEST(SignatureSerializationRoundTrip) {
+    WorldSignature signature({{"cat", 1.0}, {"hat", 0.5}});
+    signature.sort();
+    auto text = qpp::quantum::signature_to_string(signature);
+    auto parsed = qpp::quantum::signature_from_string(text);
+    QPP_EXPECT_EQ(parsed.size(), signature.size());
+    QPP_EXPECT_EQ(parsed.factors.front().first, "cat");
+    QPP_EXPECT_NEAR(parsed.factors.front().second, 1.0, 1e-12);
+    QPP_EXPECT_EQ(parsed.factors.back().first, "hat");
+    QPP_EXPECT_NEAR(parsed.factors.back().second, 0.5, 1e-12);
+}
+
+QPP_TEST(SoftmaxNormalizesProbabilities) {
+    std::vector<double> values{1.0, 2.0, 3.0};
+    auto probabilities = qpp::quantum::softmax(values);
+    double sum = std::accumulate(probabilities.begin(), probabilities.end(), 0.0);
+    QPP_EXPECT_NEAR(sum, 1.0, 1e-12);
+    for (double probability : probabilities) {
+        QPP_EXPECT_TRUE(probability >= 0.0);
+    }
+}
+
+QPP_TEST(MakeQuantumFrontBuildsConsistentData) {
+    FactorRegistry registry;
+    WorldSignature signature({{"cat", 1.0}, {"hat", 2.0}, {"pet", 0.75}});
+    auto front = qpp::quantum::make_quantum_front(registry, signature, BackendKind::CPU, 0, 1337u);
+    QPP_EXPECT_EQ(front.signature.size(), signature.size());
+    QPP_EXPECT_EQ(front.primes.size(), signature.size());
+    QPP_EXPECT_EQ(front.spectrum.size(), signature.size());
+    QPP_EXPECT_EQ(front.payload.size(), signature.size());
+    double sum = std::accumulate(front.payload.begin(), front.payload.end(), 0.0);
+    QPP_EXPECT_NEAR(sum, 1.0, 1e-9);
+}
+
+QPP_TEST(SampleWorldsQpuProducesNormalizedAmplitudes) {
+    std::vector<double> weights{0.3, 0.7, 1.1};
+    auto amplitudes = qpp::quantum::sample_worlds(weights, BackendKind::QPU_SIM, 0);
+    double norm = 0.0;
+    for (double amplitude : amplitudes)
+        norm += amplitude * amplitude;
+    QPP_EXPECT_NEAR(norm, 1.0, 1e-12);
+}
+
+QPP_TEST(SignatureFromStringHandlesWhitespaceAndDefaults) {
+    auto signature = qpp::quantum::signature_from_string(" cat : 1.0 , hat , fancy :0.25 ");
+    QPP_EXPECT_EQ(signature.size(), static_cast<std::size_t>(3));
+    QPP_EXPECT_EQ(signature.factors[0].first, "cat");
+    QPP_EXPECT_NEAR(signature.factors[0].second, 1.0, 1e-12);
+    QPP_EXPECT_EQ(signature.factors[1].first, "fancy");
+    QPP_EXPECT_NEAR(signature.factors[1].second, 0.25, 1e-12);
+    QPP_EXPECT_EQ(signature.factors[2].first, "hat");
+    QPP_EXPECT_NEAR(signature.factors[2].second, 1.0, 1e-12);
+}
+


### PR DESCRIPTION
## Summary
- define the `worlds_lib` core library together with the `world_picker` app and `worlds_tests` executable, plus updated installs
- add a lightweight C++ testing framework and register the new `worlds_tests` suite

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d1920fb250832f9a885cdc08f03854