### PR TITLE
Add quantum worlds unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,22 @@ project(qpp_tests LANGUAGES CXX)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/../qpp/backend ${CMAKE_CURRENT_BINARY_DIR}/qpp_backend)
 target_include_directories(qpp_backend PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../include)
 
+add_library(qpp_quantum_worlds STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/../qpp/quantum_worlds.cpp
+)
+target_include_directories(qpp_quantum_worlds
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/..
+)
+
+add_executable(test_worlds test_worlds.cpp)
+target_include_directories(test_worlds
+    PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}
+)
+target_link_libraries(test_worlds PRIVATE qpp_quantum_worlds)
+add_test(NAME quantum_worlds COMMAND test_worlds)
+
 option(QPP_ENABLE_HARDWARE_TESTS "Build tests requiring QPU backend" OFF)
 
 enable_testing()

--- a/tests/gtest/gtest.h
+++ b/tests/gtest/gtest.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <cmath>
+#include <exception>
+#include <functional>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace testing {
+
+namespace detail {
+template <typename T>
+std::string to_string(const T &value) {
+    if constexpr (std::is_enum_v<T>) {
+        using Underlying = std::underlying_type_t<T>;
+        return to_string(static_cast<Underlying>(value));
+    } else {
+        std::ostringstream oss;
+        oss << value;
+        return oss.str();
+    }
+}
+
+inline std::string comparison_message(const std::string &lhs_name, const std::string &lhs_value,
+                                      const std::string &rhs_name, const std::string &rhs_value) {
+    std::ostringstream oss;
+    oss << lhs_name << ": " << lhs_value << ", " << rhs_name << ": " << rhs_value;
+    return oss.str();
+}
+
+inline std::string near_message(double lhs, double rhs, double eps) {
+    std::ostringstream oss;
+    oss << "lhs: " << lhs << ", rhs: " << rhs << ", abs_error: " << eps;
+    return oss.str();
+}
+} // namespace detail
+
+struct TestFailure : public std::exception {
+    const char *what() const noexcept override { return "test failure"; }
+};
+
+using TestFunction = void (*)();
+
+struct TestInfo {
+    std::string suite;
+    std::string name;
+    TestFunction function;
+};
+
+inline std::vector<TestInfo> &registry() {
+    static std::vector<TestInfo> tests;
+    return tests;
+}
+
+struct TestRegistrar {
+    TestRegistrar(const char *suite, const char *name, TestFunction func) {
+        registry().push_back({suite, name, func});
+    }
+};
+
+inline void InitGoogleTest(int *, char **) {}
+
+inline void report_failure(const char *expr, const char *file, int line, const std::string &msg) {
+    std::cerr << file << ":" << line << ": Failure\n";
+    std::cerr << "  Expected: " << expr << "\n";
+    if (!msg.empty())
+        std::cerr << "  " << msg << "\n";
+    throw TestFailure{};
+}
+
+inline int RunAllTests() {
+    int failed = 0;
+    for (const auto &test : registry()) {
+        std::cout << "[ RUN      ] " << test.suite << "." << test.name << '\n';
+        try {
+            test.function();
+            std::cout << "[       OK ] " << test.suite << "." << test.name << '\n';
+        } catch (const TestFailure &) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.suite << "." << test.name << '\n';
+        } catch (const std::exception &ex) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.suite << "." << test.name
+                      << " (unexpected exception: " << ex.what() << ")\n";
+        } catch (...) {
+            ++failed;
+            std::cout << "[  FAILED  ] " << test.suite << "." << test.name
+                      << " (unknown exception)\n";
+        }
+    }
+    std::size_t total = registry().size();
+    if (failed == 0)
+        std::cout << "[  PASSED  ] " << total << " test" << (total == 1 ? "" : "s") << "\n";
+    else
+        std::cout << "[  FAILED  ] " << failed << " test" << (failed == 1 ? "" : "s") << "\n";
+    return failed == 0 ? 0 : 1;
+}
+
+} // namespace testing
+
+#define TEST(suite, name)                                                                     \
+    static void suite##_##name##_Test();                                                      \
+    static ::testing::TestRegistrar suite##_##name##_registrar(#suite, #name,                 \
+                                                              &suite##_##name##_Test);        \
+    static void suite##_##name##_Test()
+
+#define EXPECT_TRUE(condition)                                                                \
+    do {                                                                                      \
+        if (!(condition))                                                                     \
+            ::testing::report_failure(#condition, __FILE__, __LINE__, "condition is false"); \
+    } while (false)
+
+#define EXPECT_FALSE(condition)                                                               \
+    do {                                                                                      \
+        if (condition)                                                                        \
+            ::testing::report_failure(#condition, __FILE__, __LINE__, "condition is true");  \
+    } while (false)
+
+#define EXPECT_EQ(expected, actual)                                                                             \
+    do {                                                                                                        \
+        auto _expected = (expected);                                                                            \
+        auto _actual = (actual);                                                                                \
+        if (!(_expected == _actual))                                                                            \
+            ::testing::report_failure(#expected " == " #actual, __FILE__, __LINE__,                             \
+                                      ::testing::detail::comparison_message("expected",                        \
+                                                                            ::testing::detail::to_string(_expected), \
+                                                                            "actual",                          \
+                                                                            ::testing::detail::to_string(_actual))); \
+    } while (false)
+
+#define EXPECT_NE(val1, val2)                                                                                    \
+    do {                                                                                                         \
+        auto _v1 = (val1);                                                                                       \
+        auto _v2 = (val2);                                                                                       \
+        if (_v1 == _v2)                                                                                          \
+            ::testing::report_failure(#val1 " != " #val2, __FILE__, __LINE__,                                   \
+                                      ::testing::detail::comparison_message("val1",                             \
+                                                                            ::testing::detail::to_string(_v1),   \
+                                                                            "val2",                             \
+                                                                            ::testing::detail::to_string(_v2))); \
+    } while (false)
+
+#define EXPECT_LT(val1, val2)                                                                                    \
+    do {                                                                                                         \
+        auto _v1 = (val1);                                                                                       \
+        auto _v2 = (val2);                                                                                       \
+        if (!(_v1 < _v2))                                                                                        \
+            ::testing::report_failure(#val1 " < " #val2, __FILE__, __LINE__,                                    \
+                                      ::testing::detail::comparison_message("lhs",                              \
+                                                                            ::testing::detail::to_string(_v1),   \
+                                                                            "rhs",                              \
+                                                                            ::testing::detail::to_string(_v2))); \
+    } while (false)
+
+#define EXPECT_LE(val1, val2)                                                                                    \
+    do {                                                                                                         \
+        auto _v1 = (val1);                                                                                       \
+        auto _v2 = (val2);                                                                                       \
+        if (!(_v1 <= _v2))                                                                                       \
+            ::testing::report_failure(#val1 " <= " #val2, __FILE__, __LINE__,                                   \
+                                      ::testing::detail::comparison_message("lhs",                              \
+                                                                            ::testing::detail::to_string(_v1),   \
+                                                                            "rhs",                              \
+                                                                            ::testing::detail::to_string(_v2))); \
+    } while (false)
+
+#define EXPECT_GT(val1, val2)                                                                                    \
+    do {                                                                                                         \
+        auto _v1 = (val1);                                                                                       \
+        auto _v2 = (val2);                                                                                       \
+        if (!(_v1 > _v2))                                                                                        \
+            ::testing::report_failure(#val1 " > " #val2, __FILE__, __LINE__,                                    \
+                                      ::testing::detail::comparison_message("lhs",                              \
+                                                                            ::testing::detail::to_string(_v1),   \
+                                                                            "rhs",                              \
+                                                                            ::testing::detail::to_string(_v2))); \
+    } while (false)
+
+#define EXPECT_GE(val1, val2)                                                                                    \
+    do {                                                                                                         \
+        auto _v1 = (val1);                                                                                       \
+        auto _v2 = (val2);                                                                                       \
+        if (!(_v1 >= _v2))                                                                                       \
+            ::testing::report_failure(#val1 " >= " #val2, __FILE__, __LINE__,                                   \
+                                      ::testing::detail::comparison_message("lhs",                              \
+                                                                            ::testing::detail::to_string(_v1),   \
+                                                                            "rhs",                              \
+                                                                            ::testing::detail::to_string(_v2))); \
+    } while (false)
+
+#define EXPECT_NEAR(val1, val2, abs_error)                                                                     \
+    do {                                                                                                       \
+        auto _v1 = (val1);                                                                                      \
+        auto _v2 = (val2);                                                                                      \
+        auto _eps = (abs_error);                                                                                \
+        if (std::fabs(_v1 - _v2) > _eps)                                                                        \
+            ::testing::report_failure(#val1 " ~= " #val2, __FILE__, __LINE__,                                   \
+                                      ::testing::detail::near_message(_v1, _v2, _eps));                         \
+    } while (false)
+
+#define RUN_ALL_TESTS() ::testing::RunAllTests()
+

--- a/tests/test_worlds.cpp
+++ b/tests/test_worlds.cpp
@@ -1,0 +1,162 @@
+#include "gtest/gtest.h"
+
+#include "qpp/quantum_worlds.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <string>
+#include <vector>
+
+using namespace qpp::quantum;
+
+TEST(FactorRegistryTest, AssignsUniquePrimes) {
+    FactorRegistry registry;
+
+    auto f_with_prime = registry.register_factor("f_with");
+    auto g_relation_prime = registry.register_factor("g_relation");
+    auto ancillary_prime = registry.register_factor("ancilla");
+
+    EXPECT_EQ(static_cast<FactorRegistry::value_type>(2), f_with_prime);
+    EXPECT_NE(f_with_prime, g_relation_prime);
+    EXPECT_NE(g_relation_prime, ancillary_prime);
+    EXPECT_EQ(f_with_prime, registry.register_factor("f_with"));
+    EXPECT_TRUE(registry.contains("g_relation"));
+    EXPECT_EQ(static_cast<std::size_t>(3), registry.size());
+}
+
+TEST(SignatureParsingTest, HandlesFWithAndGRelationConstraints) {
+    WorldSignature expected;
+    expected.add_factor("g_relation", 0.75);
+    expected.add_factor("f_with", 1.25);
+    expected.sort();
+
+    auto serialized = signature_to_string(expected);
+    EXPECT_EQ(std::string("f_with:1.25,g_relation:0.75"), serialized);
+
+    auto parsed = signature_from_string(" g_relation:0.75 , f_with : 1.25 ");
+    EXPECT_EQ(expected.size(), parsed.size());
+    EXPECT_EQ(std::string("f_with"), parsed.factors[0].first);
+    EXPECT_NEAR(1.25, parsed.factors[0].second, 1e-9);
+    EXPECT_EQ(std::string("g_relation"), parsed.factors[1].first);
+    EXPECT_NEAR(0.75, parsed.factors[1].second, 1e-9);
+}
+
+TEST(SpectrumTest, MaintainsSpectralOrdering) {
+    FactorRegistry registry;
+    WorldSignature signature({{"g_relation", 0.4}, {"ancilla", 0.7}, {"f_with", 1.1}});
+    signature.sort();
+
+    auto primes = assign_primes(registry, signature);
+    EXPECT_EQ(static_cast<std::size_t>(3), primes.size());
+
+    EXPECT_EQ(std::string("ancilla"), signature.factors[0].first);
+    EXPECT_EQ(std::string("f_with"), signature.factors[1].first);
+    EXPECT_EQ(std::string("g_relation"), signature.factors[2].first);
+
+    EXPECT_EQ(static_cast<FactorRegistry::value_type>(2), primes[0]);
+    EXPECT_EQ(static_cast<FactorRegistry::value_type>(3), primes[1]);
+    EXPECT_EQ(static_cast<FactorRegistry::value_type>(5), primes[2]);
+
+    auto spectrum = generate_spectrum(primes, signature);
+    EXPECT_EQ(primes.size(), spectrum.size());
+    EXPECT_NEAR(1.4, spectrum[0], 1e-9); // 2 * 0.7
+    EXPECT_NEAR(3.3, spectrum[1], 1e-9); // 3 * 1.1
+    EXPECT_NEAR(2.0, spectrum[2], 1e-9); // 5 * 0.4
+
+    WorldSignature permuted({{"f_with", 1.1}, {"g_relation", 0.4}, {"ancilla", 0.7}});
+    permuted.sort();
+    auto primes_permuted = assign_primes(registry, permuted);
+    auto spectrum_permuted = generate_spectrum(primes_permuted, permuted);
+
+    EXPECT_EQ(primes.size(), primes_permuted.size());
+    for (std::size_t i = 0; i < primes.size(); ++i)
+        EXPECT_EQ(primes[i], primes_permuted[i]);
+
+    EXPECT_EQ(spectrum.size(), spectrum_permuted.size());
+    for (std::size_t i = 0; i < spectrum.size(); ++i)
+        EXPECT_NEAR(spectrum[i], spectrum_permuted[i], 1e-9);
+}
+
+TEST(GaussianOverlapTest, DistinguishesAlignedSpectra) {
+    std::vector<double> reference{1.4, 3.3, 5.0};
+    std::vector<double> displaced{10.0, 12.0, 14.0};
+
+    double sigma = 0.75;
+    double identical = gaussian_overlap(reference, reference, sigma);
+    double offset = gaussian_overlap(reference, displaced, sigma);
+    double symmetric = gaussian_overlap(displaced, reference, sigma);
+
+    EXPECT_GT(identical, offset);
+    EXPECT_NEAR(offset, symmetric, 1e-9);
+    EXPECT_NEAR(identical, gaussian_overlap(reference, reference, sigma), 1e-12);
+}
+
+TEST(SoftmaxTest, NormalizesAndRespectsTemperature) {
+    std::vector<double> weights{0.2, 1.0, -0.5, 0.7};
+    auto base = softmax(weights);
+
+    double sum = std::accumulate(base.begin(), base.end(), 0.0);
+    EXPECT_NEAR(1.0, sum, 1e-9);
+
+    auto max_pos = std::max_element(weights.begin(), weights.end()) - weights.begin();
+    auto max_prob = std::max_element(base.begin(), base.end()) - base.begin();
+    EXPECT_EQ(max_pos, max_prob);
+
+    auto cooled = softmax(weights, 0.5);
+    auto warmed = softmax(weights, 2.0);
+
+    EXPECT_NEAR(1.0, std::accumulate(cooled.begin(), cooled.end(), 0.0), 1e-9);
+    EXPECT_NEAR(1.0, std::accumulate(warmed.begin(), warmed.end(), 0.0), 1e-9);
+
+    EXPECT_GT(*std::max_element(cooled.begin(), cooled.end()),
+              *std::max_element(base.begin(), base.end()));
+    EXPECT_LT(*std::max_element(warmed.begin(), warmed.end()),
+              *std::max_element(base.begin(), base.end()));
+}
+
+TEST(SampleWorldsTest, CpuQpuParity) {
+    std::vector<double> weights{1.0, 2.5, 0.75, -0.5};
+
+    auto expected = softmax(weights);
+
+    auto cpu_distribution = sample_worlds(weights, BackendKind::CPU, 0, 2024);
+    EXPECT_EQ(expected.size(), cpu_distribution.size());
+    for (std::size_t i = 0; i < expected.size(); ++i)
+        EXPECT_NEAR(expected[i], cpu_distribution[i], 1e-9);
+
+    auto cpu_counts = sample_worlds(weights, BackendKind::CPU, 60000, 2024);
+    for (std::size_t i = 0; i < expected.size(); ++i)
+        EXPECT_NEAR(expected[i], cpu_counts[i], 5e-3);
+
+    auto qpu_payload = sample_worlds(weights, BackendKind::QPU_SIM, 0, 2024);
+    EXPECT_EQ(expected.size(), qpu_payload.size());
+    for (std::size_t i = 0; i < expected.size(); ++i)
+        EXPECT_NEAR(expected[i], qpu_payload[i] * qpu_payload[i], 1e-9);
+}
+
+TEST(QuantumFrontTest, BuildsConsistentWorld) {
+    FactorRegistry registry;
+    WorldSignature signature({{"f_with", 1.2}, {"g_relation", 0.6}, {"context", 0.9}});
+
+    auto front = make_quantum_front(registry, signature, BackendKind::CPU, 10000, 7);
+
+    EXPECT_EQ(BackendKind::CPU, front.backend);
+    EXPECT_EQ(signature.size(), front.signature.size());
+    EXPECT_EQ(std::string("context"), front.signature.factors[0].first);
+    EXPECT_NEAR(front.signature.factors[0].second, 0.9, 1e-9);
+
+    EXPECT_EQ(front.signature.size(), front.primes.size());
+    EXPECT_EQ(front.primes.size(), front.spectrum.size());
+
+    auto expected_probs = sample_worlds(front.spectrum, BackendKind::CPU, 0, 7);
+    EXPECT_EQ(expected_probs.size(), front.payload.size());
+    for (std::size_t i = 0; i < expected_probs.size(); ++i)
+        EXPECT_NEAR(expected_probs[i], front.payload[i], 1e-2);
+}
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+


### PR DESCRIPTION
## Summary
- add a lightweight gtest-compatible harness for building C++ unit tests
- add comprehensive quantum worlds tests covering prime registry, signature parsing, spectra, overlaps, softmax, sampling parity, and quantum front construction
- hook the new tests into the tests CMake project via a quantum_worlds library target and CTest entry

## Testing
- cmake -S tests -B build/tests
- cmake --build build/tests
- ctest --test-dir build/tests


------
https://chatgpt.com/codex/tasks/task_e_68d19205c1c4832f9d1d8f7fa591ffad