### PR TITLE
Add documentation site link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 This repository is a fork of GCC with experimental extensions for quantum programming.
 For background information on GCC itself see [README](README). The additions here focus on
-new language constructs and tooling to support quantum-aware C++ development.
+new language constructs and tooling to support quantum-aware C++ development. Full project
+documentation is available on the [Q++ website](https://sefunmi4.github.io/aoh-guild-house/projects/qpp/).
 
 ## Q++ Highlights
 


### PR DESCRIPTION
## Summary
- add a link to the hosted Q++ documentation site in the README introduction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ed1b999c832f9da8487086e2e8dd