### PR TITLE
Add pluggable qubit backend infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 enable_testing()
 
 # Core library containing the quantum worlds implementation
-add_library(worlds_lib qpp/quantum_worlds.cpp)
+add_library(worlds_lib qpp/quantum_worlds.cpp qpp/quantum/backend.cpp)
 target_include_directories(worlds_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Lightweight testing framework used by unit tests

--- a/qpp/quantum/backend.cpp
+++ b/qpp/quantum/backend.cpp
@@ -1,0 +1,284 @@
+#include "qpp/quantum/backend.hpp"
+
+#include "qpp/quantum_worlds.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace qpp {
+namespace quantum {
+
+std::vector<double> QubitBackend::run_distribution_experiment(
+    const std::vector<double> &weights, std::size_t shots) {
+    (void)weights;
+    (void)shots;
+    throw std::logic_error("distribution experiment not implemented for backend");
+}
+
+namespace {
+
+struct GateOperation {
+    enum class Kind { Single, Two };
+
+    Kind kind;
+    std::string gate;
+    std::size_t control = 0;
+    std::size_t target = 0;
+    std::vector<double> params;
+};
+
+class SoftmaxSimulatorBackend : public QubitBackend {
+  public:
+    explicit SoftmaxSimulatorBackend(BackendConfiguration config)
+        : config_(std::move(config)), qubit_count_(0), active_qubits_(), operations_(),
+          last_shots_(0), results_() {}
+
+    void reset() override {
+        qubit_count_ = 0;
+        active_qubits_.clear();
+        operations_.clear();
+        results_.clear();
+        last_shots_ = 0;
+    }
+
+    std::size_t allocate_qubit() override {
+        active_qubits_.push_back(true);
+        return qubit_count_++;
+    }
+
+    void release_qubit(std::size_t id) override {
+        if (id >= active_qubits_.size() || !active_qubits_[id])
+            throw std::out_of_range("qubit not allocated");
+        active_qubits_[id] = false;
+    }
+
+    void apply_single_qubit_gate(const std::string &gate, std::size_t target,
+                                 const std::vector<double> &params) override {
+        (void)params;
+        if (target >= active_qubits_.size() || !active_qubits_[target])
+            throw std::out_of_range("target qubit not allocated");
+        operations_.push_back({GateOperation::Kind::Single, gate, 0, target, params});
+    }
+
+    void apply_two_qubit_gate(const std::string &gate, std::size_t control, std::size_t target,
+                              const std::vector<double> &params) override {
+        (void)params;
+        if (control >= active_qubits_.size() || target >= active_qubits_.size() ||
+            !active_qubits_[control] || !active_qubits_[target])
+            throw std::out_of_range("qubits not allocated for two-qubit gate");
+        operations_.push_back({GateOperation::Kind::Two, gate, control, target, params});
+    }
+
+    void submit(std::size_t shots) override {
+        last_shots_ = shots;
+        (void)shots;
+        // The simulator operates directly on analytical distributions; nothing to do here.
+    }
+
+    std::vector<double> retrieve_results() override { return results_; }
+
+    std::vector<double> run_distribution_experiment(const std::vector<double> &weights,
+                                                    std::size_t shots) override {
+        auto probabilities = softmax(weights);
+        results_.assign(probabilities.begin(), probabilities.end());
+
+        if (config_.amplitude_output) {
+            std::vector<double> amplitudes(results_.size(), 0.0);
+            double norm = 0.0;
+            for (std::size_t i = 0; i < probabilities.size(); ++i) {
+                amplitudes[i] = std::sqrt(probabilities[i]);
+                norm += amplitudes[i] * amplitudes[i];
+            }
+            if (norm > 0.0) {
+                double inv = 1.0 / std::sqrt(norm);
+                for (double &value : amplitudes)
+                    value *= inv;
+            }
+            results_.swap(amplitudes);
+            return results_;
+        }
+
+        if (results_.empty())
+            return results_;
+
+        if (shots == 0)
+            return results_;
+
+        std::vector<double> samples(results_.size(), 0.0);
+        std::mt19937 rng(config_.seed);
+        std::discrete_distribution<std::size_t> dist(results_.begin(), results_.end());
+        for (std::size_t i = 0; i < shots; ++i)
+            ++samples[dist(rng)];
+        for (double &value : samples)
+            value /= static_cast<double>(shots);
+        results_.swap(samples);
+        return results_;
+    }
+
+  private:
+    BackendConfiguration config_;
+    std::size_t qubit_count_;
+    std::vector<bool> active_qubits_;
+    std::vector<GateOperation> operations_;
+    std::size_t last_shots_;
+    std::vector<double> results_;
+};
+
+class OpenQasmHttpBackend : public QubitBackend {
+  public:
+    explicit OpenQasmHttpBackend(BackendConfiguration config)
+        : config_(std::move(config)), qubit_count_(0), active_qubits_(), circuit_(),
+          last_shots_(0), results_() {}
+
+    void reset() override {
+        qubit_count_ = 0;
+        active_qubits_.clear();
+        circuit_.clear();
+        last_shots_ = 0;
+        results_.clear();
+    }
+
+    std::size_t allocate_qubit() override {
+        active_qubits_.push_back(true);
+        return qubit_count_++;
+    }
+
+    void release_qubit(std::size_t id) override {
+        if (id >= active_qubits_.size() || !active_qubits_[id])
+            throw std::out_of_range("qubit not allocated");
+        active_qubits_[id] = false;
+    }
+
+    void apply_single_qubit_gate(const std::string &gate, std::size_t target,
+                                 const std::vector<double> &params) override {
+        if (target >= active_qubits_.size() || !active_qubits_[target])
+            throw std::out_of_range("target qubit not allocated");
+        circuit_.push_back({GateOperation::Kind::Single, gate, 0, target, params});
+    }
+
+    void apply_two_qubit_gate(const std::string &gate, std::size_t control, std::size_t target,
+                              const std::vector<double> &params) override {
+        if (control >= active_qubits_.size() || target >= active_qubits_.size() ||
+            !active_qubits_[control] || !active_qubits_[target])
+            throw std::out_of_range("qubits not allocated for two-qubit gate");
+        circuit_.push_back({GateOperation::Kind::Two, gate, control, target, params});
+    }
+
+    void submit(std::size_t shots) override {
+        if (!config_.openqasm.submission_callback)
+            throw std::runtime_error("no submission callback configured for OpenQASM backend");
+        last_shots_ = shots;
+        auto qasm = build_program_qasm();
+        results_ = config_.openqasm.submission_callback(qasm, shots, config_.openqasm);
+    }
+
+    std::vector<double> retrieve_results() override { return results_; }
+
+    std::vector<double> run_distribution_experiment(const std::vector<double> &weights,
+                                                    std::size_t shots) override {
+        last_shots_ = shots;
+
+        if (config_.openqasm.submission_callback) {
+            auto qasm = build_distribution_qasm(weights);
+            results_ =
+                config_.openqasm.submission_callback(qasm, shots, config_.openqasm);
+            return results_;
+        }
+
+        auto probabilities = softmax(weights);
+        if (probabilities.empty()) {
+            results_.clear();
+            return results_;
+        }
+
+        if (shots == 0) {
+            results_ = probabilities;
+            return results_;
+        }
+
+        std::vector<double> samples(probabilities.size(), 0.0);
+        std::mt19937 rng(config_.seed);
+        std::discrete_distribution<std::size_t> dist(probabilities.begin(), probabilities.end());
+        for (std::size_t i = 0; i < shots; ++i)
+            ++samples[dist(rng)];
+        for (double &value : samples)
+            value /= static_cast<double>(shots);
+        results_.swap(samples);
+        return results_;
+    }
+
+  private:
+    std::string build_program_qasm() const {
+        std::ostringstream oss;
+        oss << "OPENQASM 2.0;\n";
+        oss << "include \"qelib1.inc\";\n";
+        oss << "qreg q[" << std::max<std::size_t>(qubit_count_, active_qubits_.size())
+            << "];\n";
+        oss << "creg c[" << std::max<std::size_t>(qubit_count_, active_qubits_.size())
+            << "];\n";
+        for (const auto &op : circuit_) {
+            if (op.kind == GateOperation::Kind::Single) {
+                oss << op.gate << " q[" << op.target << "]";
+            } else {
+                oss << op.gate << " q[" << op.control << "],q[" << op.target << "]";
+            }
+            if (!op.params.empty()) {
+                oss << "(";
+                for (std::size_t i = 0; i < op.params.size(); ++i) {
+                    if (i > 0)
+                        oss << ',';
+                    oss << op.params[i];
+                }
+                oss << ")";
+            }
+            oss << ";\n";
+        }
+        oss << "measure q -> c;\n";
+        return oss.str();
+    }
+
+    std::string build_distribution_qasm(const std::vector<double> &weights) const {
+        std::ostringstream oss;
+        oss << "OPENQASM 2.0;\n";
+        oss << "// Distribution sampling request\n";
+        oss << "// endpoint: " << config_.openqasm.endpoint << "\n";
+        oss << "// backend: " << config_.openqasm.backend << "\n";
+        oss << "// weights:";
+        for (double value : weights)
+            oss << ' ' << value;
+        oss << "\n";
+        oss << "// shots: " << last_shots_ << "\n";
+        return oss.str();
+    }
+
+    BackendConfiguration config_;
+    std::size_t qubit_count_;
+    std::vector<bool> active_qubits_;
+    std::vector<GateOperation> circuit_;
+    std::size_t last_shots_;
+    std::vector<double> results_;
+};
+
+} // namespace
+
+std::unique_ptr<QubitBackend> make_backend(BackendKind kind, BackendConfiguration config) {
+    switch (kind) {
+    case BackendKind::CPU:
+        config.amplitude_output = false;
+        return std::make_unique<SoftmaxSimulatorBackend>(std::move(config));
+    case BackendKind::QPU_SIM:
+        config.amplitude_output = true;
+        return std::make_unique<SoftmaxSimulatorBackend>(std::move(config));
+    case BackendKind::OPENQASM_HTTP:
+        config.amplitude_output = false;
+        return std::make_unique<OpenQasmHttpBackend>(std::move(config));
+    }
+    throw std::invalid_argument("unknown backend kind");
+}
+
+} // namespace quantum
+} // namespace qpp
+

--- a/qpp/quantum/backend.hpp
+++ b/qpp/quantum/backend.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace qpp {
+namespace quantum {
+
+enum class BackendKind;
+
+struct BackendConfiguration {
+    unsigned seed = 0;
+    std::size_t max_qubits = 0;
+    bool amplitude_output = false;
+
+    struct OpenQasmHttpConfiguration {
+        std::string endpoint;
+        std::string api_token;
+        std::string backend;
+        std::unordered_map<std::string, std::string> headers;
+        std::function<std::vector<double>(const std::string &, std::size_t,
+                                          const OpenQasmHttpConfiguration &)
+                      > submission_callback;
+
+        bool enabled() const noexcept { return !endpoint.empty(); }
+    } openqasm;
+
+    std::unordered_map<std::string, std::string> user_data;
+};
+
+class QubitBackend {
+  public:
+    virtual ~QubitBackend() = default;
+
+    virtual void reset() = 0;
+
+    virtual std::size_t allocate_qubit() = 0;
+
+    virtual void release_qubit(std::size_t id) = 0;
+
+    virtual void apply_single_qubit_gate(const std::string &gate, std::size_t target,
+                                         const std::vector<double> &params = {}) = 0;
+
+    virtual void apply_two_qubit_gate(const std::string &gate, std::size_t control,
+                                      std::size_t target,
+                                      const std::vector<double> &params = {}) = 0;
+
+    virtual void submit(std::size_t shots) = 0;
+
+    virtual std::vector<double> retrieve_results() = 0;
+
+    virtual std::vector<double>
+    run_distribution_experiment(const std::vector<double> &weights, std::size_t shots);
+};
+
+std::unique_ptr<QubitBackend> make_backend(BackendKind kind, BackendConfiguration config);
+
+} // namespace quantum
+} // namespace qpp
+

--- a/qpp/quantum_worlds.cpp
+++ b/qpp/quantum_worlds.cpp
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cctype>
 #include <cmath>
-#include <random>
 #include <sstream>
 #include <stdexcept>
 
@@ -36,6 +35,8 @@ BackendKind parse_backend(std::string_view name) {
         return BackendKind::CPU;
     if (lowered == "qpu_sim" || lowered == "qpu-sim" || lowered == "qpu")
         return BackendKind::QPU_SIM;
+    if (lowered == "openqasm_http" || lowered == "openqasm-http" || lowered == "openqasm")
+        return BackendKind::OPENQASM_HTTP;
     throw std::invalid_argument("unknown backend: " + std::string{name});
 }
 
@@ -184,35 +185,18 @@ std::vector<double> softmax(const std::vector<double> &values, double temperatur
 }
 
 std::vector<double> sample_worlds(const std::vector<double> &weights, BackendKind backend,
-                                  std::size_t shots, unsigned seed) {
-    auto probabilities = softmax(weights);
-    if (backend == BackendKind::CPU) {
-        if (probabilities.empty())
-            return {};
-        if (shots == 0)
-            return probabilities;
-        std::vector<double> samples(probabilities.size(), 0.0);
-        std::mt19937 rng(seed);
-        std::discrete_distribution<std::size_t> dist(probabilities.begin(), probabilities.end());
-        for (std::size_t i = 0; i < shots; ++i)
-            samples[dist(rng)] += 1.0;
-        for (double &v : samples)
-            v /= static_cast<double>(shots);
-        return samples;
-    }
+                                  std::size_t shots, BackendConfiguration config) {
+    if (config.max_qubits == 0)
+        config.max_qubits = weights.size();
+    auto backend_impl = make_backend(backend, std::move(config));
+    return backend_impl->run_distribution_experiment(weights, shots);
+}
 
-    std::vector<double> amplitudes(probabilities.size(), 0.0);
-    double norm = 0.0;
-    for (std::size_t i = 0; i < probabilities.size(); ++i) {
-        amplitudes[i] = std::sqrt(probabilities[i]);
-        norm += amplitudes[i] * amplitudes[i];
-    }
-    if (norm > 0.0) {
-        double inv = 1.0 / std::sqrt(norm);
-        for (double &v : amplitudes)
-            v *= inv;
-    }
-    return amplitudes;
+std::vector<double> sample_worlds(const std::vector<double> &weights, BackendKind backend,
+                                  std::size_t shots, unsigned seed) {
+    BackendConfiguration config;
+    config.seed = seed;
+    return sample_worlds(weights, backend, shots, std::move(config));
 }
 
 QuantumFront make_quantum_front(FactorRegistry &registry, const WorldSignature &signature,

--- a/qpp/quantum_worlds.hpp
+++ b/qpp/quantum_worlds.hpp
@@ -8,13 +8,16 @@
 #include <utility>
 #include <vector>
 
+#include "qpp/quantum/backend.hpp"
+
 namespace qpp {
 namespace quantum {
 
 /** \brief Enumeration describing which backend is targeted. */
 enum class BackendKind {
     CPU,
-    QPU_SIM
+    QPU_SIM,
+    OPENQASM_HTTP
 };
 
 /** \brief Convert a textual backend identifier into a BackendKind. */
@@ -95,6 +98,9 @@ std::vector<double> softmax(const std::vector<double> &values, double temperatur
  *  returned vector contains normalized amplitudes derived from the softmax
  *  distribution.
  */
+std::vector<double> sample_worlds(const std::vector<double> &weights, BackendKind backend,
+                                  std::size_t shots, BackendConfiguration config);
+
 std::vector<double> sample_worlds(const std::vector<double> &weights, BackendKind backend,
                                   std::size_t shots, unsigned seed = 0);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(qpp_backend PUBLIC ${CMAKE_CURRENT_LIST_DIR}/../inclu
 
 add_library(qpp_quantum_worlds STATIC
     ${CMAKE_CURRENT_LIST_DIR}/../qpp/quantum_worlds.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/../qpp/quantum/backend.cpp
 )
 target_include_directories(qpp_quantum_worlds
     PUBLIC

--- a/tests/test_worlds.cpp
+++ b/tests/test_worlds.cpp
@@ -135,6 +135,34 @@ TEST(SampleWorldsTest, CpuQpuParity) {
         EXPECT_NEAR(expected[i], qpu_payload[i] * qpu_payload[i], 1e-9);
 }
 
+TEST(BackendParsingTest, RecognizesOpenQasmBackend) {
+    EXPECT_EQ(BackendKind::OPENQASM_HTTP, parse_backend("openqasm"));
+    EXPECT_EQ(BackendKind::OPENQASM_HTTP, parse_backend("OPENQASM-HTTP"));
+}
+
+TEST(OpenQasmBackendTest, SupportsCallbackSubmission) {
+    std::vector<double> weights{0.4, 1.6};
+    BackendConfiguration config;
+    config.openqasm.endpoint = "https://example.invalid/jobs";
+    config.openqasm.backend = "example-device";
+    bool invoked = false;
+    config.openqasm.submission_callback =
+        [&invoked](const std::string &qasm, std::size_t shots,
+                   const BackendConfiguration::OpenQasmHttpConfiguration &http) {
+            invoked = true;
+            EXPECT_FALSE(qasm.empty());
+            EXPECT_EQ(42u, shots);
+            EXPECT_EQ(std::string("https://example.invalid/jobs"), http.endpoint);
+            return std::vector<double>{0.25, 0.75};
+        };
+
+    auto results = sample_worlds(weights, BackendKind::OPENQASM_HTTP, 42, config);
+    ASSERT_EQ(std::size_t{2}, results.size());
+    EXPECT_NEAR(0.25, results[0], 1e-9);
+    EXPECT_NEAR(0.75, results[1], 1e-9);
+    EXPECT_TRUE(invoked);
+}
+
 TEST(QuantumFrontTest, BuildsConsistentWorld) {
     FactorRegistry registry;
     WorldSignature signature({{"f_with", 1.2}, {"g_relation", 0.6}, {"context", 0.9}});


### PR DESCRIPTION
## Summary
- introduce a pluggable `QubitBackend` API with a softmax simulator and OpenQASM-over-HTTP adapter
- route `sample_worlds` through the new backend factory and extend backend parsing to cover the adapter
- update build scripts and tests to cover backend selection and callback configuration

## Testing
- cmake -S . -B build
- cmake --build build
- ctest --test-dir build


------
https://chatgpt.com/codex/tasks/task_e_68d2ac8d13e4832f9e08d008d14c4794