### PR TITLE
Add probabilistic measurement helpers for qint

### DIFF
--- a/docs/architecture/02-runtime.md
+++ b/docs/architecture/02-runtime.md
@@ -23,7 +23,12 @@ across different components.
 `qregister` and `cregister` provide explicit quantum and classical
 storage. A `qregister` wraps a `qclass` instance and exposes import and
 export helpers so that state can be saved or restored. `cregister` stores
-ordinary integer bits for hybrid algorithms.
+ordinary integer bits for hybrid algorithms. When higher level helpers
+such as `qint` allocate qubits they now rely on backend-provided
+measurement helpers (`measure_axis` / `measure_register`) to collapse the
+state. These helpers surface the probabilities and sampled counts returned
+by the backend so runtime code can react differently to
+non-deterministic results versus legacy deterministic fallbacks.
 
 ## Raw Gate Injection
 

--- a/docs/data-structures/quantum_containers.md
+++ b/docs/data-structures/quantum_containers.md
@@ -16,6 +16,10 @@ amplitudes, each instance now requests qubit allocations from a backend
 simulates the legacy behaviour—constructors accept integers and translate them
 into the ±1 orientations described below—but you can inject your own backend to
 route allocation and preparation into an actual simulator or piece of hardware.
+The lifecycle is explicit: constructing a `qint` allocates four qubits (`x`,
+`y`, `z`, and `t`), preparation functions load orientations or amplitude
+schedules, and measurement helpers collapse the state while returning the
+statistics required by downstream code.
 
 | Axis | Legacy negative (`-1`) meaning | Legacy positive (`+1`) meaning |
 | ---- | ------------------------------ | ------------------------------ |
@@ -31,12 +35,31 @@ that axis is reused; otherwise the sign of the value is taken as the target
 orientation while the raw magnitude is forwarded so that real backends can infer
 their own gate schedules.
 
-Convenience accessors—`x_step()`, `y_step()`, `z_step()`, and `t_step()`—now
-return `MeasurementHandle`s. Sampling a handle triggers a deferred measurement
-through the backend, with results cached inside the `qint` so repeated probes do
-not collapse the state multiple times. The `std::hash<qint>` specialisation uses
-these cached samples, ensuring hashed containers observe stable values even when
-the underlying qubits were allocated lazily.
+For amplitude-driven workflows call `prepare_normalized_amplitudes(frequency, …)`.
+The helper computes `sin(f · axis_index)` for each axis, normalises the samples,
+and asks the backend to stage a single submission. Depending on the supplied
+probability interpretation (`AbsoluteAmplitude` vs `SquaredAmplitude`) the
+weights are normalised before being translated into rotation angles. Measuring
+such a state yields the familiar `sin²(f · x)` distribution over the positive
+orientations.
+
+Convenience accessors—`x_step()`, `y_step()`, `z_step()`, and `t_step()`—return
+`MeasurementHandle`s that sample a single axis. Each probe requests statistics
+from the backend, collapses the qubit to the reported classical orientation, and
+caches the collapsed value so repeated probes do not trigger additional
+measurements. The richer helpers `measure_axis(axis, shots)` and
+`measure_register(shots)` return `MeasurementStatistics` objects containing
+probabilities, sampled counts (when `shots > 0`), and the collapsed classical
+value. Inspecting these structs lets higher-level code distinguish between true
+probabilistic results (for example, from `prepare_normalized_amplitudes`) and
+legacy deterministic orientations.
+
+Because measurements can now be non-deterministic, the surrounding containers
+react accordingly: once a qubit has been prepared with a sine-weighted schedule
+the first measurement collapses according to the backend RNG, but subsequent
+reads observe the cached classical value. The `std::hash<qint>` specialisation
+respects this behaviour by feeding the cached samples into its mixing routine so
+that hashed containers remain stable after the first observation.
 
 ## `qvector`: quantum-friendly dynamic arrays
 
@@ -100,6 +123,10 @@ return false;
 
 Try modifying the `context` epoch between runs or mixing `qint` constructions
 (some using the shared legacy backend, others pointing at a custom backend) to
-experiment with how the data structures react. Because these helpers are thin
-abstractions over standard containers, they are safe playgrounds for bridging
-classical algorithm drills and quantum intuition.
+experiment with how the data structures react. Pay particular attention to how
+probabilistic measurements propagate: sine-weighted preparations will report
+`sin²(f · x)` frequencies when you gather statistics with `measure_register`,
+while the legacy constructors continue to collapse immediately to their ±1
+orientations. Because these helpers are thin abstractions over standard
+containers, they are safe playgrounds for bridging classical algorithm drills
+and quantum intuition.

--- a/include/qpp/qint
+++ b/include/qpp/qint
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <functional>
 #include <optional>
+#include <random>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -33,7 +34,9 @@ struct qint {
     struct QubitHandle {
         std::size_t id{};
 
-        friend bool operator==(const QubitHandle&, const QubitHandle&) = default;
+        friend bool operator==(const QubitHandle& lhs, const QubitHandle& rhs) noexcept {
+            return lhs.id == rhs.id;
+        }
     };
 
     /// Abstract backend API used to allocate and prepare qubits.
@@ -48,6 +51,25 @@ struct qint {
         enum class ProbabilityInterpretation {
             AbsoluteAmplitude,
             SquaredAmplitude,
+        };
+
+        /// Statistics gathered from measuring a qubit axis.
+        struct MeasurementStatistics {
+            std::unordered_map<int, double> probabilities;
+            std::unordered_map<int, unsigned> counts;
+            std::optional<int> collapsed_value;
+
+            [[nodiscard]] bool has_counts() const noexcept {
+                return !counts.empty();
+            }
+
+            [[nodiscard]] bool has_probabilities() const noexcept {
+                return !probabilities.empty();
+            }
+
+            [[nodiscard]] bool has_collapsed_value() const noexcept {
+                return collapsed_value.has_value();
+            }
         };
 
         struct AmplitudePreparationRequest {
@@ -75,7 +97,8 @@ struct qint {
             const AmplitudePreparationSchedule& schedule) = 0;
 
         /// Perform a measurement and collapse the qubit.
-        [[nodiscard]] virtual int measure(const QubitHandle& handle) = 0;
+        [[nodiscard]] virtual MeasurementStatistics measure(const QubitHandle& handle,
+                                                            std::size_t shots) = 0;
     };
 
     /// Deferred measurement of a specific axis.
@@ -149,6 +172,28 @@ struct qint {
     /// Deferred measurement handle for the t-axis orientation.
     [[nodiscard]] MeasurementHandle t_step() const noexcept {
         return MeasurementHandle{this, 3U};
+    }
+
+    using MeasurementStatistics = Backend::MeasurementStatistics;
+
+    /// Measure a single axis and retrieve statistics from the backend.
+    [[nodiscard]] MeasurementStatistics measure_axis(std::size_t axis_index,
+                                                     std::size_t shots = 0) const {
+        auto stats = backend_->measure(qubits_[axis_index], shots);
+        stats = finalize_statistics(axis_index, shots, std::move(stats));
+        const int collapsed = interpret_statistics(axis_index, stats);
+        measurement_cache_[axis_index] = collapsed;
+        last_orientations_[axis_index] = collapsed;
+        return stats;
+    }
+
+    /// Measure all axes, collecting statistics for each register component.
+    [[nodiscard]] std::array<MeasurementStatistics, 4>
+    measure_register(std::size_t shots = 0) const {
+        std::array<MeasurementStatistics, 4> results{};
+        for (std::size_t axis = 0; axis < results.size(); ++axis)
+            results[axis] = measure_axis(axis, shots);
+        return results;
     }
 
     /// Equality comparison for unordered containers and direct comparison.
@@ -258,15 +303,55 @@ private:
 
     [[nodiscard]] int sample_axis(std::size_t axis_index) const {
         auto& cached = measurement_cache_[axis_index];
-        if (!cached.has_value())
-            cached = backend_->measure(qubits_[axis_index]);
+        if (!cached.has_value()) {
+            auto stats = backend_->measure(qubits_[axis_index], 0);
+            stats = finalize_statistics(axis_index, 0, std::move(stats));
+            const int collapsed = interpret_statistics(axis_index, stats);
+            cached = collapsed;
+            last_orientations_[axis_index] = collapsed;
+        }
         return *cached;
     }
 
     Backend* backend_{};
     std::array<QubitHandle, 4> qubits_{};
     mutable std::array<std::optional<int>, 4> measurement_cache_{};
-    std::array<int, 4> last_orientations_{};
+    mutable std::array<int, 4> last_orientations_{};
+
+    [[nodiscard]] MeasurementStatistics finalize_statistics(
+        std::size_t axis_index, std::size_t shots, MeasurementStatistics stats) const {
+        if (!stats.has_collapsed_value() && !stats.has_probabilities() && !stats.has_counts()) {
+            const int orientation = last_orientations_[axis_index];
+            stats.collapsed_value = orientation;
+            stats.probabilities[orientation] = 1.0;
+            if (shots > 0)
+                stats.counts[orientation] = static_cast<unsigned>(shots);
+        }
+        return stats;
+    }
+
+    [[nodiscard]] int interpret_statistics(std::size_t axis_index,
+                                           MeasurementStatistics& stats) const {
+        if (stats.collapsed_value)
+            return *stats.collapsed_value;
+        if (!stats.counts.empty()) {
+            auto it = std::max_element(stats.counts.begin(), stats.counts.end(),
+                                       [](const auto& lhs, const auto& rhs) {
+                                           return lhs.second < rhs.second;
+                                       });
+            stats.collapsed_value = it->first;
+            return it->first;
+        }
+        if (!stats.probabilities.empty()) {
+            auto it = std::max_element(stats.probabilities.begin(), stats.probabilities.end(),
+                                       [](const auto& lhs, const auto& rhs) {
+                                           return lhs.second < rhs.second;
+                                       });
+            stats.collapsed_value = it->first;
+            return it->first;
+        }
+        return last_orientations_[axis_index];
+    }
 
     friend struct std::hash<qint>;
 };
@@ -303,8 +388,55 @@ struct qint::LegacyGateSequenceBackend final : public qint::Backend {
         }
     }
 
-    int measure(const QubitHandle& handle) override {
-        return states_.at(handle.id).orientation;
+    MeasurementStatistics measure(const QubitHandle& handle,
+                                  std::size_t shots) override {
+        auto& entry = states_.at(handle.id);
+        MeasurementStatistics stats;
+
+        auto finalize_collapse = [&](int orientation) {
+            stats.collapsed_value = orientation;
+            stats.probabilities[orientation] = 1.0;
+            if (shots > 0)
+                stats.counts[orientation] = static_cast<unsigned>(shots);
+            entry.orientation = orientation;
+            entry.amplitude_prepared = false;
+            entry.used_sine_weighting = false;
+            entry.legacy_value = orientation;
+        };
+
+        if (entry.amplitude_prepared) {
+            double prob_one = std::clamp(entry.amplitude * entry.amplitude, 0.0, 1.0);
+            stats.probabilities[1] = prob_one;
+            stats.probabilities[-1] = std::clamp(1.0 - prob_one, 0.0, 1.0);
+
+            std::bernoulli_distribution draw(prob_one);
+            int collapsed = -1;
+
+            if (shots > 0) {
+                unsigned ones = 0;
+                for (std::size_t i = 0; i < shots; ++i) {
+                    bool sample = draw(rng_);
+                    collapsed = sample ? 1 : -1;
+                    if (sample)
+                        ++ones;
+                }
+                stats.counts[1] = ones;
+                stats.counts[-1] = static_cast<unsigned>(shots) - ones;
+                stats.collapsed_value = collapsed;
+            } else {
+                collapsed = draw(rng_) ? 1 : -1;
+                stats.collapsed_value = collapsed;
+            }
+
+            entry.orientation = *stats.collapsed_value;
+            entry.amplitude_prepared = false;
+            entry.used_sine_weighting = false;
+            entry.legacy_value = *stats.collapsed_value;
+        } else {
+            finalize_collapse(entry.orientation);
+        }
+
+        return stats;
     }
 
 private:
@@ -323,6 +455,7 @@ private:
 
     std::size_t next_id_{};
     std::unordered_map<std::size_t, State> states_{};
+    std::mt19937 rng_{5489u};
 };
 
 inline qint::Backend& qint::default_backend() {

--- a/qpp/tests/test_sim_algorithms.py
+++ b/qpp/tests/test_sim_algorithms.py
@@ -139,6 +139,84 @@ int main(){
         out = self.compile_and_run(code, 'encodings')
         self.assertEqual(out, 'ok')
 
+    def test_qint_measurements_follow_sine_distribution(self):
+        code = r"""#include <array>
+#include <cmath>
+#include <iostream>
+#include "qpp/qint"
+int main(){
+    qint state;
+    double frequency = 0.73;
+    state.prepare_normalized_amplitudes(frequency);
+    auto stats = state.measure_register(4096);
+    std::array<double,4> expected{};
+    double total = 0.0;
+    for (std::size_t axis = 0; axis < expected.size(); ++axis) {
+        double sample = std::sin(frequency * static_cast<double>(axis));
+        expected[axis] = sample * sample;
+        total += expected[axis];
+    }
+    if (total == 0.0)
+        total = 1.0;
+    bool ok = true;
+    for (std::size_t axis = 0; axis < expected.size(); ++axis) {
+        double target = expected[axis] / total;
+        double observed_prob = 0.0;
+        auto pit = stats[axis].probabilities.find(1);
+        if (pit != stats[axis].probabilities.end())
+            observed_prob = pit->second;
+        double observed_freq = 0.0;
+        auto cit = stats[axis].counts.find(1);
+        if (cit != stats[axis].counts.end())
+            observed_freq = static_cast<double>(cit->second) / 4096.0;
+        if (!stats[axis].collapsed_value.has_value())
+            ok = false;
+        if (std::abs(observed_prob - target) > 0.05 ||
+            std::abs(observed_freq - target) > 0.08) {
+            ok = false;
+            break;
+        }
+    }
+    std::cout << (ok ? "ok" : "fail") << '\n';
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'qint_sine_measure')
+        self.assertEqual(out, 'ok')
+
+    def test_qint_measurement_classical_fallback(self):
+        code = r"""#include <array>
+#include <cmath>
+#include <iostream>
+#include "qpp/qint"
+int main(){
+    qint state(-1, 1, -1, 1);
+    auto stats = state.measure_register();
+    const std::array<int,4> expected{{-1, 1, -1, 1}};
+    bool ok = true;
+    for (std::size_t axis = 0; axis < expected.size(); ++axis) {
+        if (!stats[axis].collapsed_value.has_value() ||
+            stats[axis].collapsed_value.value() != expected[axis]) {
+            ok = false;
+            break;
+        }
+        auto pit = stats[axis].probabilities.find(expected[axis]);
+        if (pit == stats[axis].probabilities.end() || std::abs(pit->second - 1.0) > 1e-9) {
+            ok = false;
+            break;
+        }
+        if (!stats[axis].counts.empty()) {
+            ok = false;
+            break;
+        }
+    }
+    std::cout << (ok ? "ok" : "fail") << '\n';
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'qint_classical_measure')
+        self.assertEqual(out, 'ok')
+
     def test_period_finding(self):
         code = r"""#include <iostream>
 #include "qpp/sim/PeriodFinding.hpp"


### PR DESCRIPTION
## Summary
- extend `qint` to gather measurement statistics via the backend and expose `measure_axis`/`measure_register`
- document the new qubit lifecycle, sine-weighted preparations, and probabilistic measurement semantics
- add simulator regression tests that check for sin² sampling behaviour and legacy deterministic collapse

## Testing
- pytest qpp/tests/test_sim_algorithms.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d10e7044832fac2f3176fc17c51b