### PR TITLE
Add sliding window algorithm examples

### DIFF
--- a/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
+++ b/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qstruct.hpp"
+
+namespace qpp::examples::sliding_window {
+
+/// Compute the maximum profit achievable with a single buy/sell transaction.
+inline int best_time_to_buy_and_sell_stock(const std::vector<int>& prices) {
+    int best_profit = 0;
+    int cheapest_so_far = std::numeric_limits<int>::max();
+    for (int price : prices) {
+        cheapest_so_far = std::min(cheapest_so_far, price);
+        best_profit = std::max(best_profit, price - cheapest_so_far);
+    }
+    return best_profit;
+}
+
+/// Length of the longest substring without repeating characters.
+inline int longest_substring_without_repeating_characters(std::string_view s) {
+    std::array<int, 256> last_seen;
+    last_seen.fill(-1);
+
+    int best = 0;
+    int window_start = 0;
+    for (int i = 0; i < static_cast<int>(s.size()); ++i) {
+        const unsigned char ch = static_cast<unsigned char>(s[static_cast<std::size_t>(i)]);
+        if (last_seen[ch] >= window_start)
+            window_start = last_seen[ch] + 1;
+        last_seen[ch] = i;
+        best = std::max(best, i - window_start + 1);
+    }
+    return best;
+}
+
+/// Longest substring obtainable after replacing at most k characters.
+inline int longest_repeating_character_replacement(std::string_view s, int k) {
+    if (s.empty())
+        return 0;
+
+    std::array<int, 256> frequency{};
+    int window_start = 0;
+    int max_frequency_in_window = 0;
+    int best = 0;
+
+    for (int i = 0; i < static_cast<int>(s.size()); ++i) {
+        const unsigned char ch = static_cast<unsigned char>(s[static_cast<std::size_t>(i)]);
+        max_frequency_in_window = std::max(max_frequency_in_window, ++frequency[ch]);
+
+        while (i - window_start + 1 - max_frequency_in_window > k) {
+            const unsigned char left_char =
+                static_cast<unsigned char>(s[static_cast<std::size_t>(window_start)]);
+            --frequency[left_char];
+            ++window_start;
+        }
+
+        best = std::max(best, i - window_start + 1);
+    }
+    return best;
+}
+
+/// Minimum length substring of text that contains all characters of pattern.
+inline std::string minimum_window_substring(std::string_view text,
+                                            std::string_view pattern) {
+    if (pattern.empty() || text.empty() || pattern.size() > text.size())
+        return {};
+
+    std::array<int, 256> required{};
+    for (unsigned char ch : pattern)
+        ++required[ch];
+
+    int missing = static_cast<int>(pattern.size());
+    std::size_t window_start = 0;
+    std::size_t best_start = 0;
+    std::size_t best_length = std::numeric_limits<std::size_t>::max();
+
+    for (std::size_t window_end = 0; window_end < text.size(); ++window_end) {
+        const unsigned char ch = static_cast<unsigned char>(text[window_end]);
+        if (required[ch] > 0)
+            --missing;
+        --required[ch];
+
+        while (missing == 0) {
+            const std::size_t current_length = window_end - window_start + 1;
+            if (current_length < best_length) {
+                best_length = current_length;
+                best_start = window_start;
+            }
+
+            const unsigned char left_char =
+                static_cast<unsigned char>(text[window_start]);
+            ++required[left_char];
+            if (required[left_char] > 0)
+                ++missing;
+            ++window_start;
+        }
+    }
+
+    if (best_length == std::numeric_limits<std::size_t>::max())
+        return {};
+    return std::string{text.substr(best_start, best_length)};
+}
+
+/// Probability that a random window contains the target index.
+inline qpp::pbool window_hit_probability(std::size_t text_length,
+                                         std::size_t window_length,
+                                         std::size_t target_index) {
+    if (text_length == 0 || window_length == 0 || target_index >= text_length)
+        return qpp::pbool{0.0};
+    if (window_length >= text_length)
+        return qpp::pbool{1.0};
+
+    const std::size_t max_start = text_length - window_length;
+    const std::size_t total_windows = max_start + 1;
+
+    const std::size_t min_start =
+        target_index >= window_length - 1 ? target_index - (window_length - 1) : 0;
+    const std::size_t max_covering_start =
+        std::min<std::size_t>(target_index, max_start);
+
+    std::size_t covering = 0;
+    if (min_start <= max_covering_start)
+        covering = max_covering_start - min_start + 1;
+
+    return qpp::pbool(static_cast<double>(covering) /
+                      static_cast<double>(total_windows));
+}
+
+/// Build a register representing a uniform superposition of valid window starts.
+inline qpp::qclass make_window_superposition(std::size_t text_length,
+                                             std::size_t window_length) {
+    if (text_length == 0 || window_length == 0 || window_length > text_length)
+        return qpp::qclass{};
+
+    const std::size_t window_count = text_length - window_length + 1;
+    std::size_t qubits = 0;
+    while ((std::size_t{1} << qubits) < window_count)
+        ++qubits;
+
+    qpp::qclass reg(qubits);
+    if (qubits == 0)
+        return reg;
+
+    for (std::size_t q = 0; q < qubits; ++q)
+        reg.apply_h(q);
+
+    auto& amplitude = reg.data().amplitude;
+    for (std::size_t basis = window_count; basis < amplitude.size(); ++basis)
+        amplitude[basis] = {0.0, 0.0};
+
+    double norm = 0.0;
+    for (const auto& amp : amplitude)
+        norm += std::norm(amp);
+    if (norm > 0.0) {
+        const double inv_norm = 1.0 / std::sqrt(norm);
+        for (auto& amp : amplitude)
+            amp *= inv_norm;
+    }
+
+    return reg;
+}
+
+} // namespace qpp::examples::sliding_window
+

--- a/examples/data-structures-and-algorithms/sliding-window/sliding_window.qpp
+++ b/examples/data-structures-and-algorithms/sliding-window/sliding_window.qpp
@@ -1,0 +1,55 @@
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "sliding_window.hpp"
+
+namespace {
+void print_state(const qpp::qstruct& state, const std::string& label) {
+    const std::size_t qubits = state.qubits();
+    std::cout << label << " (" << qubits << " qubits) amplitudes:\n";
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const double probability = std::norm(state.amplitude[i]);
+        if (probability < 1e-6)
+            continue;
+        std::cout << "  |";
+        for (std::size_t q = 0; q < qubits; ++q)
+            std::cout << (((i >> (qubits - q - 1)) & 1u) ? '1' : '0');
+        std::cout << "> -> " << state.amplitude[i] << " (p=" << probability << ")\n";
+    }
+}
+} // namespace
+
+int main() {
+    using namespace qpp::examples::sliding_window;
+
+    const std::vector<int> prices{7, 1, 5, 3, 6, 4};
+    std::cout << "best_time_to_buy_and_sell_stock([7,1,5,3,6,4]) -> "
+              << best_time_to_buy_and_sell_stock(prices) << "\n";
+
+    const std::string unique_span = "abcabcbb";
+    std::cout << "longest_substring_without_repeating_characters('abcabcbb') -> "
+              << longest_substring_without_repeating_characters(unique_span) << "\n";
+
+    const std::string repeating = "AABABBA";
+    std::cout << "longest_repeating_character_replacement('AABABBA', 1) -> "
+              << longest_repeating_character_replacement(repeating, 1) << "\n";
+
+    const std::string text = "ADOBECODEBANC";
+    const std::string pattern = "ABC";
+    std::cout << "minimum_window_substring('ADOBECODEBANC', 'ABC') -> '"
+              << minimum_window_substring(text, pattern) << "'\n";
+
+    const qpp::pbool hit = window_hit_probability(12, 4, 5);
+    std::cout << std::fixed << std::setprecision(3)
+              << "window_hit_probability(text_length=12, window_length=4, target_index=5) -> "
+              << hit.probability() << "\n";
+
+    auto register_state = make_window_superposition(8, 3);
+    print_state(register_state.data(),
+                "Uniform superposition of window starts for length=8, window=3");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement classical sliding window solutions for stock profit, substring, character replacement, and minimum window problems
- add probabilistic helpers modelling sliding window selection in the quantum playground API
- provide a demonstration program that exercises the new helpers and prints representative outputs

## Testing
- g++ -std=c++17 -x c++ -Iinclude -I. examples/data-structures-and-algorithms/sliding-window/sliding_window.qpp -o /tmp/sliding_window_example
- /tmp/sliding_window_example

------
https://chatgpt.com/codex/tasks/task_e_68d3173f3b7c832fa126ddc87b870829