### PR TITLE
Add register repository rule-of-five helper

### DIFF
--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
@@ -4,6 +4,7 @@
 #include <array>
 #include <cmath>
 #include <complex>
+#include <memory>
 #include <numeric>
 #include <stdexcept>
 #include <string>
@@ -21,6 +22,64 @@
 
 
 namespace qpp::examples::arrays_and_hashing {
+// -----------------------------------------------------------------------------
+// Register storage helper obeying the rule of five
+// -----------------------------------------------------------------------------
+
+/// Small helper that owns a dynamically allocated qclass instance and exposes
+/// the full rule-of-five interface so that it can be copied or moved around by
+/// the examples in the accompanying .qpp file.
+class register_repository {
+public:
+    register_repository() = default;
+
+    explicit register_repository(const qpp::qclass& reg)
+        : reg_(std::make_unique<qpp::qclass>(reg)) {}
+
+    ~register_repository() = default;
+
+    register_repository(const register_repository& other)
+        : reg_(other.reg_ ? std::make_unique<qpp::qclass>(*other.reg_) : nullptr) {}
+
+    register_repository(register_repository&& other) noexcept = default;
+
+    register_repository& operator=(const register_repository& other) {
+        if (this != &other) {
+            reg_ =
+                other.reg_ ? std::make_unique<qpp::qclass>(*other.reg_) : nullptr;
+        }
+        return *this;
+    }
+
+    register_repository& operator=(register_repository&& other) noexcept =
+        default;
+
+    /// Replace the stored register with a deep copy of the provided one.
+    void store(const qpp::qclass& reg) {
+        reg_ = std::make_unique<qpp::qclass>(reg);
+    }
+
+    /// True when a register is currently stored.
+    [[nodiscard]] bool has_register() const noexcept { return static_cast<bool>(reg_); }
+
+    /// Access the stored register (const).
+    [[nodiscard]] const qpp::qclass& retrieve() const {
+        if (!reg_)
+            throw std::runtime_error("register_repository::retrieve: empty store");
+        return *reg_;
+    }
+
+    /// Access the stored register (mutable).
+    [[nodiscard]] qpp::qclass& retrieve() {
+        if (!reg_)
+            throw std::runtime_error("register_repository::retrieve: empty store");
+        return *reg_;
+    }
+
+private:
+    std::unique_ptr<qpp::qclass> reg_{};
+};
+
 // -----------------------------------------------------------------------------
 // Classical helper algorithms
 // -----------------------------------------------------------------------------

--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
@@ -177,6 +177,19 @@ int main() {
     print_state(qubit_register.data(), "Analog qubit register");
     std::cout << '\n';
 
+    register_repository repository;
+    repository.store(qubit_register);
+    register_repository cloned_repository = repository; // copy constructor
+    register_repository moved_repository =
+        std::move(cloned_repository); // move constructor
+
+    std::cout << "register_repository stored qubits -> "
+              << moved_repository.retrieve().data().qubits() << '\n';
+    moved_repository.retrieve().apply_x(0);
+    std::cout << "register_repository after apply_x ->\n";
+    print_state(moved_repository.retrieve().data(), "  updated register");
+    std::cout << '\n';
+
     // Hybrid [b, q, b, q] register built from helper outputs
     const std::vector<int> hybrid_bits{1, 0};
     const std::vector<double> hybrid_angles{pi / 4.0, pi / 2.5};


### PR DESCRIPTION
## Summary
- add a register_repository helper that owns a qclass instance with an explicit rule-of-five implementation for the data structures and algorithms examples
- demonstrate storing, copying, and moving the repository within the arrays_and_hashing.qpp example

## Testing
- not run (examples do not have an automated build target in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d5a287e3b0832fae5b072056ff97e0