### PR TITLE
Add greedy algorithms example implementation

### DIFF
--- a/examples/data-structures-and-algorithms/greedy/greedy.hpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <complex>
+#include <cmath>
+#include <vector>
+
+#include "qpp/qstruct.hpp"
+
+namespace qpp::examples::greedy {
+
+/// Return the maximum sum obtainable from a contiguous subarray.
+inline int maximum_subarray(const std::vector<int>& nums) {
+    if (nums.empty())
+        return 0;
+
+    int best = nums.front();
+    int current = nums.front();
+    for (std::size_t i = 1; i < nums.size(); ++i) {
+        current = std::max(nums[i], current + nums[i]);
+        best = std::max(best, current);
+    }
+    return best;
+}
+
+
+/// Determine whether it is possible to reach the last index.
+inline bool can_jump(const std::vector<int>& nums) {
+    std::size_t furthest = 0;
+    for (std::size_t i = 0; i < nums.size(); ++i) {
+        if (i > furthest)
+            return false;
+        const std::size_t step = static_cast<std::size_t>(std::max(nums[i], 0));
+        furthest = std::max(furthest, i + step);
+        if (furthest + 1 >= nums.size())
+            return true;
+    }
+    return true;
+}
+
+/// Build a register encoding reachable prefixes for the jump game instance.
+inline qpp::qclass reachable_prefix_superposition(const std::vector<int>& nums) {
+    const std::size_t n = nums.size();
+    std::size_t qubits = 0;
+    while ((std::size_t{1} << qubits) < std::max<std::size_t>(n, 1))
+        ++qubits;
+
+    qpp::qclass reg(qubits);
+    if (qubits == 0)
+        return reg;
+
+    for (std::size_t q = 0; q < qubits; ++q)
+        reg.apply_h(q);
+
+    auto& amplitude = reg.data().amplitude;
+    for (std::size_t basis = n; basis < amplitude.size(); ++basis)
+        amplitude[basis] = {0.0, 0.0};
+
+    if (n == 0)
+        return reg;
+
+    std::size_t furthest = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        if (i > furthest)
+            break;
+        const std::size_t step = static_cast<std::size_t>(std::max(nums[i], 0));
+        const std::size_t reach = i + step;
+        if (reach > furthest)
+            furthest = std::min<std::size_t>(reach, n - 1);
+    }
+
+    for (std::size_t basis = furthest + 1; basis < n; ++basis)
+        amplitude[basis] = {0.0, 0.0};
+
+    double norm = 0.0;
+    for (const auto& amp : amplitude)
+        norm += std::norm(amp);
+
+    if (norm > 0.0) {
+        const double inv_norm = 1.0 / std::sqrt(norm);
+        for (auto& amp : amplitude)
+            amp *= inv_norm;
+    }
+
+    return reg;
+}
+
+} // namespace qpp::examples::greedy
+

--- a/examples/data-structures-and-algorithms/greedy/greedy.qpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.qpp
@@ -1,4 +1,49 @@
-namespace qpp::examples::greedy {
-    Maximum Subarray   	
-    Jump Game   
+#include <complex>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "greedy.hpp"
+
+namespace {
+std::string basis_string(std::size_t index, std::size_t qubits) {
+    std::string bits(qubits, '0');
+    for (std::size_t q = 0; q < qubits; ++q)
+        bits[qubits - q - 1] = ((index >> q) & 1u) ? '1' : '0';
+    return bits;
 }
+
+void print_state(const qpp::qstruct& state, const std::string& label) {
+    const std::size_t qubits = state.qubits();
+    std::cout << label << " (" << qubits << " qubits) amplitudes:\n";
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const double probability = std::norm(state.amplitude[i]);
+        if (probability < 1e-9)
+            continue;
+        std::cout << "  |" << basis_string(i, qubits) << "> -> "
+                  << state.amplitude[i] << " (p=" << probability << ")\n";
+    }
+}
+} // namespace
+
+int main() {
+    using namespace qpp::examples::greedy;
+
+    const std::vector<int> sequence{-2, 1, -3, 4, -1, 2, 1, -5, 4};
+    std::cout << "maximum_subarray([-2,1,-3,4,-1,2,1,-5,4]) -> "
+              << maximum_subarray(sequence) << "\n";
+
+    const std::vector<int> jumps_success{2, 3, 1, 1, 4};
+    const std::vector<int> jumps_failure{3, 2, 1, 0, 4};
+    std::cout << std::boolalpha;
+    std::cout << "can_jump([2,3,1,1,4]) -> " << can_jump(jumps_success) << "\n";
+    std::cout << "can_jump([3,2,1,0,4]) -> " << can_jump(jumps_failure) << "\n";
+
+    auto register_state = reachable_prefix_superposition(jumps_success);
+    print_state(register_state.data(),
+                "Reachable prefixes superposition for [2,3,1,1,4]");
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- implement greedy helper algorithms for the maximum subarray and jump game demonstrations
- add a greedy example driver that prints classical results and the reachable-prefix superposition

## Testing
- `g++ -std=c++17 -x c++ -I include -I . examples/data-structures-and-algorithms/greedy/greedy.qpp -o /tmp/greedy_example`
- `/tmp/greedy_example`


------
https://chatgpt.com/codex/tasks/task_e_68d5a3a76d40832f8c674445076fb358