### PR TITLE
Add two-pointer algorithm examples

### DIFF
--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
@@ -1,0 +1,213 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qint"
+#include "qpp/qstruct.hpp"
+#include "qpp/qvector"
+
+namespace qpp::examples::two_pointers {
+
+/// Determine whether a string is a palindrome after removing non-alphanumeric
+/// characters and ignoring letter case.
+inline bool valid_palindrome(std::string_view s) {
+    std::size_t left = 0;
+    std::size_t right = s.size();
+
+    while (left < right) {
+        while (left < right &&
+               !std::isalnum(static_cast<unsigned char>(s[static_cast<std::size_t>(left)])))
+            ++left;
+        while (left < right &&
+               !std::isalnum(static_cast<unsigned char>(s[static_cast<std::size_t>(right - 1)])))
+            --right;
+        if (left >= right)
+            break;
+
+        const unsigned char left_char =
+            static_cast<unsigned char>(s[static_cast<std::size_t>(left)]);
+        const unsigned char right_char =
+            static_cast<unsigned char>(s[static_cast<std::size_t>(right - 1)]);
+        if (std::tolower(left_char) != std::tolower(right_char))
+            return false;
+
+        ++left;
+        --right;
+    }
+
+    return true;
+}
+
+/// Determine whether a string is a palindrome using the same rules as the
+/// classical counterpart.
+inline bool quantum_valid_palindrome(std::string_view s) {
+    return valid_palindrome(s);
+}
+
+/// Probability wrapper describing confidence that the provided string is a
+/// palindrome.
+inline qpp::pbool palindrome_bias(std::string_view s) {
+    return qpp::pbool{valid_palindrome(s) ? 1.0 : 0.0};
+}
+
+/// Enumerate all unique triplets that sum to zero.
+inline std::vector<std::array<int, 3>> three_sum(const std::vector<int>& nums) {
+    if (nums.size() < 3)
+        return {};
+
+    std::vector<int> sorted(nums.begin(), nums.end());
+    std::sort(sorted.begin(), sorted.end());
+
+    std::vector<std::array<int, 3>> result;
+    for (std::size_t i = 0; i < sorted.size(); ++i) {
+        if (i > 0 && sorted[i] == sorted[i - 1])
+            continue;
+
+        std::size_t left = i + 1;
+        std::size_t right = sorted.size() - 1;
+        while (left < right) {
+            const long current = static_cast<long>(sorted[i]) +
+                                 static_cast<long>(sorted[left]) +
+                                 static_cast<long>(sorted[right]);
+            if (current < 0) {
+                ++left;
+            } else if (current > 0) {
+                --right;
+            } else {
+                result.push_back({sorted[i], sorted[left], sorted[right]});
+                ++left;
+                --right;
+                while (left < right && sorted[left] == sorted[left - 1])
+                    ++left;
+                while (left < right && sorted[right] == sorted[right + 1])
+                    --right;
+            }
+        }
+    }
+
+    return result;
+}
+
+/// Enumerate all unique triplets that sum to zero over quantum integers.
+inline std::vector<std::array<qint, 3>> quantum_three_sum(std::qvector<qint> nums) {
+    if (nums.size() < 3)
+        return {};
+
+    std::sort(nums.begin(), nums.end());
+
+    std::vector<std::array<qint, 3>> result;
+    for (std::size_t i = 0; i < nums.size(); ++i) {
+        if (i > 0 && nums[i] == nums[i - 1])
+            continue;
+
+        std::size_t left = i + 1;
+        std::size_t right = nums.size() - 1;
+        while (left < right) {
+            const qint current = nums[i] + nums[left] + nums[right];
+            if (current < 0) {
+                ++left;
+            } else if (current > 0) {
+                --right;
+            } else {
+                result.push_back({nums[i], nums[left], nums[right]});
+                ++left;
+                --right;
+                while (left < right && nums[left] == nums[left - 1])
+                    ++left;
+                while (left < right && nums[right] == nums[right + 1])
+                    --right;
+            }
+        }
+    }
+
+    return result;
+}
+
+/// Compute the largest area that can be formed between two vertical lines.
+inline int container_with_most_water(const std::vector<int>& height) {
+    if (height.size() < 2)
+        return 0;
+
+    std::size_t left = 0;
+    std::size_t right = height.size() - 1;
+    int best = 0;
+
+    while (left < right) {
+        const int min_height =
+            std::min(height[left], height[right]);
+        const int width = static_cast<int>(right - left);
+        best = std::max(best, min_height * width);
+
+        if (height[left] < height[right])
+            ++left;
+        else
+            --right;
+    }
+
+    return best;
+}
+
+/// Compute the largest container area using quantum integers.
+inline qint quantum_container_with_most_water(const std::qvector<qint>& height) {
+    if (height.size() < 2)
+        return 0;
+
+    std::size_t left = 0;
+    std::size_t right = height.size() - 1;
+    qint best = 0;
+
+    while (left < right) {
+        const qint min_height = std::min(height[left], height[right]);
+        const qint width = static_cast<qint>(right - left);
+        best = std::max(best, min_height * width);
+
+        if (height[left] < height[right])
+            ++left;
+        else
+            --right;
+    }
+
+    return best;
+}
+
+/// Build a register representing a uniform superposition of pointer positions.
+inline qpp::qclass make_pointer_superposition(std::size_t length) {
+    if (length == 0)
+        return qpp::qclass{};
+
+    std::size_t qubits = 0;
+    while ((std::size_t{1} << qubits) < length)
+        ++qubits;
+
+    qpp::qclass reg(qubits);
+    for (std::size_t q = 0; q < qubits; ++q)
+        reg.apply_h(q);
+    return reg;
+}
+
+/// Probability that a randomly sampled pair of pointers intersects the target
+/// index.
+inline qpp::pbool pointer_hit_probability(std::size_t length, std::size_t target) {
+    if (length == 0 || target >= length)
+        return qpp::pbool{0.0};
+
+    const double numerator = static_cast<double>(target + 1) *
+                              static_cast<double>(length - target);
+    const double denominator =
+        static_cast<double>(length) * static_cast<double>(length + 1) / 2.0;
+    return qpp::pbool{numerator / denominator};
+}
+
+} // namespace qpp::examples::two_pointers
+

--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
@@ -1,0 +1,108 @@
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "two_pointers.hpp"
+
+namespace {
+std::string basis_string(std::size_t index, std::size_t qubits) {
+    std::string bits(qubits, '0');
+    for (std::size_t q = 0; q < qubits; ++q)
+        bits[qubits - q - 1] = ((index >> q) & 1u) ? '1' : '0';
+    return bits;
+}
+
+void print_state(const qpp::qstruct& state, const std::string& label) {
+    const std::size_t qubits = state.qubits();
+    std::cout << label << " (" << qubits << " qubits) amplitudes:\n";
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const double probability = std::norm(state.amplitude[i]);
+        if (probability < 1e-9)
+            continue;
+        std::cout << "  |" << basis_string(i, qubits) << "> -> "
+                  << state.amplitude[i] << " (p=" << probability << ")\n";
+    }
+}
+
+int as_classical(const ::qint& value) {
+    auto stats = value.measure_register();
+    int result = 0;
+    for (std::size_t axis = 0; axis < stats.size(); ++axis) {
+        result <<= 1;
+        result |= stats[axis].collapsed_value.value_or(0) == 1 ? 1 : 0;
+    }
+    return result;
+}
+}
+
+int main() {
+    using namespace qpp::examples::two_pointers;
+
+    std::cout << std::boolalpha;
+
+    const std::string palindrome_sample = "A man, a plan, a canal: Panama";
+    const std::string non_palindrome_sample = "quantum register";
+    std::cout << "valid_palindrome('" << palindrome_sample << "') -> "
+              << valid_palindrome(palindrome_sample) << '\n';
+    std::cout << "valid_palindrome('" << non_palindrome_sample << "') -> "
+              << valid_palindrome(non_palindrome_sample) << '\n';
+
+    std::cout << "quantum_valid_palindrome('Able was I ere I saw Elba') -> "
+              << quantum_valid_palindrome("Able was I ere I saw Elba") << '\n';
+    std::cout << "palindrome_bias('madam') -> "
+              << palindrome_bias("madam").probability() << '\n';
+
+    const std::vector<int> nums{-1, 0, 1, 2, -1, -4};
+    const auto triplets = three_sum(nums);
+    std::cout << "three_sum([-1,0,1,2,-1,-4]) ->\n";
+    for (const auto& triplet : triplets) {
+        std::cout << "  [" << triplet[0] << ", " << triplet[1] << ", " << triplet[2]
+                  << "]\n";
+    }
+
+    const std::qvector<::qint> quantum_nums{
+        static_cast<::qint>(-1),
+        static_cast<::qint>(0),
+        static_cast<::qint>(1),
+        static_cast<::qint>(2),
+        static_cast<::qint>(-1),
+        static_cast<::qint>(-4),
+    };
+    const auto quantum_triplets = quantum_three_sum(quantum_nums);
+    std::cout << "quantum_three_sum([-1,0,1,2,-1,-4]) ->\n";
+    for (const auto& triplet : quantum_triplets) {
+        std::cout << "  [" << as_classical(triplet[0]) << ", "
+                  << as_classical(triplet[1]) << ", "
+                  << as_classical(triplet[2]) << "]\n";
+    }
+
+    const std::vector<int> heights{1, 8, 6, 2, 5, 4, 8, 3, 7};
+    std::cout << "container_with_most_water([1,8,6,2,5,4,8,3,7]) -> "
+              << container_with_most_water(heights) << '\n';
+
+    const std::qvector<::qint> quantum_heights{
+        static_cast<::qint>(1),
+        static_cast<::qint>(8),
+        static_cast<::qint>(6),
+        static_cast<::qint>(2),
+        static_cast<::qint>(5),
+        static_cast<::qint>(4),
+        static_cast<::qint>(8),
+        static_cast<::qint>(3),
+        static_cast<::qint>(7),
+    };
+    std::cout << "quantum_container_with_most_water([...]) -> "
+              << as_classical(quantum_container_with_most_water(quantum_heights))
+              << '\n';
+
+    const auto pointer_state = make_pointer_superposition(8);
+    print_state(pointer_state.data(), "Pointer superposition for length=8");
+
+    std::cout << std::setprecision(4)
+              << "pointer_hit_probability(8, 3) -> "
+              << pointer_hit_probability(8, 3).probability() << '\n';
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a two-pointers example header that implements classical and quantum variants of valid palindrome, three-sum, and container-with-most-water helpers, along with utility probability routines
- provide a matching .qpp driver showcasing the algorithms and printing register information

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d709d29e28832faf19846fa7a0bb91