### PR TITLE
Add bit manipulation problem examples

### DIFF
--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qint"
+#include "qpp/qstruct.hpp"
+#include "qpp/qvector"
+
+namespace qpp::examples::bit_manipulation {
+
+/// Count the number of set bits (population count) in the provided value.
+inline int hamming_weight(std::uint32_t value) {
+    int count = 0;
+    while (value != 0U) {
+        value &= value - 1U;
+        ++count;
+    }
+    return count;
+}
+
+/// Count the number of set bits for a quantum integer by delegating to the
+/// classical counterpart.
+inline int quantum_hamming_weight(const qint& value) {
+    return hamming_weight(static_cast<std::uint32_t>(static_cast<int>(value)));
+}
+
+/// Build the array containing the population count of each value in [0, n].
+inline std::vector<int> counting_bits(int n) {
+    if (n < 0)
+        return {};
+
+    std::vector<int> result(static_cast<std::size_t>(n) + 1, 0);
+    for (int i = 1; i <= n; ++i)
+        result[static_cast<std::size_t>(i)] =
+            result[static_cast<std::size_t>(i >> 1)] + (i & 1);
+    return result;
+}
+
+/// Compute population counts for the range [0, n] and encode them as quantum
+/// integers.
+inline std::qvector<qint> quantum_counting_bits(int n) {
+    const auto classical = counting_bits(n);
+    std::qvector<qint> result;
+    result.reserve(classical.size());
+    for (int value : classical)
+        result.push_back(static_cast<qint>(value));
+    return result;
+}
+
+/// Reverse the bits of a 32-bit unsigned integer.
+inline std::uint32_t reverse_bits(std::uint32_t value) {
+    value = ((value & 0x55555555u) << 1U) | ((value >> 1U) & 0x55555555u);
+    value = ((value & 0x33333333u) << 2U) | ((value >> 2U) & 0x33333333u);
+    value = ((value & 0x0F0F0F0Fu) << 4U) | ((value >> 4U) & 0x0F0F0F0Fu);
+    value = ((value & 0x00FF00FFu) << 8U) | ((value >> 8U) & 0x00FF00FFu);
+    value = (value << 16U) | (value >> 16U);
+    return value;
+}
+
+/// Reverse the bits of a quantum integer treated as a 32-bit value.
+inline qint quantum_reverse_bits(const qint& value) {
+    return static_cast<qint>(reverse_bits(static_cast<std::uint32_t>(static_cast<int>(value))));
+}
+
+/// Given an array containing the range [0, n] with a missing element, return
+/// the missing value.
+inline int missing_number(const std::vector<int>& nums) {
+    int xor_accumulator = static_cast<int>(nums.size());
+    for (std::size_t i = 0; i < nums.size(); ++i) {
+        xor_accumulator ^= static_cast<int>(i);
+        xor_accumulator ^= nums[i];
+    }
+    return xor_accumulator;
+}
+
+/// Return the missing value in the quantum variant of the problem.
+inline qint quantum_missing_number(const std::qvector<qint>& nums) {
+    std::vector<int> classical;
+    classical.reserve(nums.size());
+    for (const auto& value : nums)
+        classical.push_back(static_cast<int>(value));
+    return static_cast<qint>(missing_number(classical));
+}
+
+/// Compute the sum of two integers using bitwise operations only.
+inline int sum_two_integers(int a, int b) {
+    while (b != 0) {
+        const int carry = (a & b) << 1U;
+        a ^= b;
+        b = carry;
+    }
+    return a;
+}
+
+/// Compute the bitwise sum of two quantum integers.
+inline qint quantum_sum_two_integers(const qint& a, const qint& b) {
+    return static_cast<qint>(sum_two_integers(static_cast<int>(a), static_cast<int>(b)));
+}
+
+/// Probability wrapper describing whether a value has even parity.
+inline qpp::pbool even_parity_probability(std::uint32_t value) {
+    return qpp::pbool{(hamming_weight(value) % 2 == 0) ? 1.0 : 0.0};
+}
+
+/// Prepare a register encoding a uniform superposition across the provided
+/// number of bits.
+inline qpp::qclass make_uniform_bit_superposition(std::size_t bit_width) {
+    qpp::qclass reg(bit_width);
+    for (std::size_t q = 0; q < bit_width; ++q)
+        reg.apply_h(q);
+    return reg;
+}
+
+} // namespace qpp::examples::bit_manipulation
+

--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
@@ -1,0 +1,104 @@
+#include <bitset>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "bit_manipulation.hpp"
+
+namespace {
+std::string basis_string(std::size_t index, std::size_t qubits) {
+    std::string bits(qubits, '0');
+    for (std::size_t q = 0; q < qubits; ++q)
+        bits[qubits - q - 1] = ((index >> q) & 1u) ? '1' : '0';
+    return bits;
+}
+
+void print_state(const qpp::qstruct& state, const std::string& label) {
+    const std::size_t qubits = state.qubits();
+    std::cout << label << " (" << qubits << " qubits) amplitudes:\n";
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i) {
+        const double probability = std::norm(state.amplitude[i]);
+        if (probability < 1e-9)
+            continue;
+        std::cout << "  |" << basis_string(i, qubits) << "> -> "
+                  << state.amplitude[i] << " (p=" << probability << ")\n";
+    }
+}
+
+int as_classical(const ::qint& value) {
+    auto stats = value.measure_register();
+    int result = 0;
+    for (std::size_t axis = 0; axis < stats.size(); ++axis) {
+        result <<= 1;
+        result |= stats[axis].collapsed_value.value_or(0) == 1 ? 1 : 0;
+    }
+    return result;
+}
+} // namespace
+
+int main() {
+    using namespace qpp::examples::bit_manipulation;
+
+    std::cout << std::boolalpha;
+
+    const std::uint32_t sample = 0b101101001u;
+    std::cout << "hamming_weight(0b101101001) -> " << hamming_weight(sample) << '\n';
+    std::cout << "reverse_bits(0b101101001) -> 0b"
+              << std::bitset<32>(reverse_bits(sample)) << '\n';
+
+    const auto counts = counting_bits(10);
+    std::cout << "counting_bits(10) -> [";
+    for (std::size_t i = 0; i < counts.size(); ++i) {
+        std::cout << counts[i];
+        if (i + 1 != counts.size())
+            std::cout << ", ";
+    }
+    std::cout << "]\n";
+
+    const std::vector<int> missing_input{3, 0, 1};
+    std::cout << "missing_number([3,0,1]) -> " << missing_number(missing_input) << '\n';
+    std::cout << "sum_two_integers(5, -3) -> " << sum_two_integers(5, -3) << '\n';
+
+    const std::qvector<::qint> quantum_values{
+        static_cast<::qint>(sample),
+    };
+    std::cout << "quantum_hamming_weight(0b101101001) -> "
+              << quantum_hamming_weight(quantum_values.front()) << '\n';
+    std::cout << "quantum_reverse_bits(0b101101001) -> 0b"
+              << std::bitset<32>(static_cast<std::uint32_t>(
+                     static_cast<int>(quantum_reverse_bits(quantum_values.front()))))
+              << '\n';
+
+    const auto quantum_counts = quantum_counting_bits(5);
+    std::cout << "quantum_counting_bits(5) -> [";
+    for (std::size_t i = 0; i < quantum_counts.size(); ++i) {
+        std::cout << as_classical(quantum_counts[i]);
+        if (i + 1 != quantum_counts.size())
+            std::cout << ", ";
+    }
+    std::cout << "]\n";
+
+    const std::qvector<::qint> quantum_missing{
+        static_cast<::qint>(3),
+        static_cast<::qint>(0),
+        static_cast<::qint>(1),
+    };
+    std::cout << "quantum_missing_number([3,0,1]) -> "
+              << as_classical(quantum_missing_number(quantum_missing)) << '\n';
+
+    std::cout << "quantum_sum_two_integers(5, -3) -> "
+              << as_classical(quantum_sum_two_integers(static_cast<::qint>(5),
+                                                       static_cast<::qint>(-3)))
+              << '\n';
+
+    auto superposition = make_uniform_bit_superposition(3);
+    print_state(superposition.data(), "Uniform bit superposition for 3 qubits");
+
+    std::cout << std::setprecision(3)
+              << "even_parity_probability(0b101101001) -> "
+              << even_parity_probability(sample).probability() << '\n';
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a bit manipulation example module covering hamming weight, counting bits, bit reversal, missing number, and sum via bitwise operations with classical and quantum variants
- provide a demonstration driver showing how to use the new routines and helper utilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d712ded1a8832f9a0657bf653cbe3b