### PR TITLE
Add stack parentheses validation example

### DIFF
--- a/examples/data-structures-and-algorithms/stack/stack_problems.hpp
+++ b/examples/data-structures-and-algorithms/stack/stack_problems.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qint"
+#include "qpp/qvector"
+
+namespace qpp::examples::stack {
+namespace detail {
+
+constexpr std::array<char, 6> kBracketSymbols{'(', ')', '[', ']', '{', '}'};
+
+[[nodiscard]] constexpr bool is_open_symbol(char symbol) noexcept {
+    return symbol == '(' || symbol == '[' || symbol == '{';
+}
+
+[[nodiscard]] constexpr bool is_supported_symbol(char symbol) noexcept {
+    for (char candidate : kBracketSymbols)
+        if (candidate == symbol)
+            return true;
+    return false;
+}
+
+[[nodiscard]] constexpr bool is_matching_pair(char open_symbol,
+                                              char close_symbol) noexcept {
+    return (open_symbol == '(' && close_symbol == ')') ||
+           (open_symbol == '[' && close_symbol == ']') ||
+           (open_symbol == '{' && close_symbol == '}');
+}
+
+[[nodiscard]] constexpr int encode_symbol(char symbol) noexcept {
+    for (std::size_t index = 0; index < kBracketSymbols.size(); ++index)
+        if (kBracketSymbols[index] == symbol)
+            return static_cast<int>(index);
+    return -1;
+}
+
+[[nodiscard]] constexpr char decode_symbol(int token) noexcept {
+    return (token >= 0 && token < static_cast<int>(kBracketSymbols.size()))
+               ? kBracketSymbols[static_cast<std::size_t>(token)]
+               : '\0';
+}
+
+template <typename FetchSymbol>
+[[nodiscard]] inline bool validate_sequence(std::size_t length,
+                                            FetchSymbol&& fetch_symbol) {
+    std::vector<char> symbols;
+    symbols.reserve(length);
+
+    for (std::size_t index = 0; index < length; ++index) {
+        const char symbol = fetch_symbol(index);
+        if (!is_supported_symbol(symbol))
+            return false;
+
+        if (is_open_symbol(symbol)) {
+            symbols.push_back(symbol);
+            continue;
+        }
+
+        if (symbols.empty() || !is_matching_pair(symbols.back(), symbol))
+            return false;
+
+        symbols.pop_back();
+    }
+
+    return symbols.empty();
+}
+
+} // namespace detail
+
+/// Determine whether the provided bracket string is valid.
+inline bool is_valid_parentheses(std::string_view s) {
+    return detail::validate_sequence(s.size(),
+                                     [&](std::size_t index) {
+                                         return s[static_cast<std::size_t>(index)];
+                                     });
+}
+
+/// Determine whether a sequence of encoded bracket tokens is valid.
+inline bool quantum_is_valid_parentheses(const std::qvector<qint>& sequence) {
+    return detail::validate_sequence(sequence.size(),
+                                     [&](std::size_t index) {
+                                         const int token =
+                                             static_cast<int>(sequence[index]);
+                                         return detail::decode_symbol(token);
+                                     });
+}
+
+/// Express confidence in the validity of the provided bracket string.
+inline qpp::pbool parentheses_confidence(std::string_view s) {
+    return qpp::pbool{is_valid_parentheses(s) ? 1.0 : 0.0};
+}
+
+/// Convert a bracket string into a quantum-friendly encoding of bracket tokens.
+inline std::qvector<qint> encode_parentheses_sequence(std::string_view s) {
+    std::qvector<qint> encoded;
+    encoded.reserve(s.size());
+
+    for (char symbol : s) {
+        const int token = detail::encode_symbol(symbol);
+        if (token < 0)
+            throw std::invalid_argument(
+                "encode_parentheses_sequence: unsupported bracket symbol");
+        encoded.emplace_back(token);
+    }
+
+    return encoded;
+}
+
+/// Convert an encoded bracket sequence back into its string representation.
+inline std::string decode_parentheses_sequence(const std::qvector<qint>& sequence) {
+    std::string decoded;
+    decoded.reserve(sequence.size());
+
+    for (const auto& token : sequence) {
+        const char symbol = detail::decode_symbol(static_cast<int>(token));
+        if (!detail::is_supported_symbol(symbol))
+            throw std::invalid_argument(
+                "decode_parentheses_sequence: invalid bracket token");
+        decoded.push_back(symbol);
+    }
+
+    return decoded;
+}
+
+} // namespace qpp::examples::stack
+

--- a/examples/data-structures-and-algorithms/stack/stack_problems.qpp
+++ b/examples/data-structures-and-algorithms/stack/stack_problems.qpp
@@ -1,0 +1,38 @@
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+#include "stack_problems.hpp"
+
+int main() {
+    using namespace qpp::examples::stack;
+
+    const std::string valid = "({[]})";
+    const std::string invalid = "([)]";
+
+    std::cout << std::boolalpha;
+    std::cout << "is_valid_parentheses(\"" << valid << "\") -> "
+              << is_valid_parentheses(valid) << "\n";
+    std::cout << "is_valid_parentheses(\"" << invalid << "\") -> "
+              << is_valid_parentheses(invalid) << "\n";
+
+    const auto encoded_valid = encode_parentheses_sequence(valid);
+    const auto encoded_invalid = encode_parentheses_sequence(invalid);
+
+    std::cout << "quantum_is_valid_parentheses(\"" << valid << "\") -> "
+              << quantum_is_valid_parentheses(encoded_valid) << "\n";
+    std::cout << "quantum_is_valid_parentheses(\"" << invalid << "\") -> "
+              << quantum_is_valid_parentheses(encoded_invalid) << "\n";
+
+    const auto confidence_valid = parentheses_confidence(valid);
+    const auto confidence_invalid = parentheses_confidence(invalid);
+
+    std::cout << std::setprecision(1) << std::fixed;
+    std::cout << "parentheses_confidence(\"" << valid << "\") -> "
+              << confidence_valid.probability() << "\n";
+    std::cout << "parentheses_confidence(\"" << invalid << "\") -> "
+              << confidence_invalid.probability() << "\n";
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a stack-based data structures and algorithms example for validating bracket sequences
- provide helper utilities for encoding sequences for quantum-friendly experimentation
- add a sample driver that demonstrates classical, quantum, and probabilistic APIs

## Testing
- not run (examples only)


------
https://chatgpt.com/codex/tasks/task_e_68dec6227da4832f9266d3dfac6d8e70