### PR TITLE
Add binary tree data structure and algorithm examples

### DIFF
--- a/examples/data-structures-and-algorithms/tree/tree_problems.hpp
+++ b/examples/data-structures-and-algorithms/tree/tree_problems.hpp
@@ -1,0 +1,326 @@
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace qpp::examples::tree {
+
+struct TreeNode {
+    int value{};
+    std::shared_ptr<TreeNode> left{};
+    std::shared_ptr<TreeNode> right{};
+};
+
+using NodePtr = std::shared_ptr<TreeNode>;
+
+inline NodePtr make_node(int value, NodePtr left = nullptr, NodePtr right = nullptr) {
+    return std::make_shared<TreeNode>(TreeNode{value, std::move(left), std::move(right)});
+}
+
+inline NodePtr make_tree(const std::vector<std::optional<int>>& values) {
+    if (values.empty() || !values.front())
+        return nullptr;
+
+    std::vector<NodePtr> nodes(values.size());
+    nodes.front() = make_node(*values.front());
+
+    for (std::size_t index = 0; index < values.size(); ++index) {
+        const auto& value = values[index];
+        if (!value)
+            continue;
+
+        auto& node = nodes[index];
+        if (!node)
+            node = make_node(*value);
+
+        const auto left_index = 2 * index + 1;
+        const auto right_index = 2 * index + 2;
+
+        if (left_index < values.size() && values[left_index]) {
+            nodes[left_index] = make_node(*values[left_index]);
+            node->left = nodes[left_index];
+        }
+
+        if (right_index < values.size() && values[right_index]) {
+            nodes[right_index] = make_node(*values[right_index]);
+            node->right = nodes[right_index];
+        }
+    }
+
+    return nodes.front();
+}
+
+inline std::string serialize(const NodePtr& root) {
+    if (!root)
+        return "null";
+
+    std::ostringstream stream;
+    std::queue<NodePtr> queue;
+    queue.push(root);
+
+    bool first = true;
+    while (!queue.empty()) {
+        const auto node = queue.front();
+        queue.pop();
+
+        if (!first)
+            stream << ',';
+        first = false;
+
+        if (node) {
+            stream << node->value;
+            queue.push(node->left);
+            queue.push(node->right);
+        } else {
+            stream << '#';
+        }
+    }
+
+    return stream.str();
+}
+
+inline NodePtr deserialize(const std::string& data) {
+    if (data == "null" || data.empty())
+        return nullptr;
+
+    std::vector<std::optional<int>> values;
+    std::size_t start = 0;
+    while (start <= data.size()) {
+        const auto end = data.find(',', start);
+        const auto token = data.substr(start, end == std::string::npos ? std::string::npos : end - start);
+        if (token == "#" || token == "null") {
+            values.push_back(std::nullopt);
+        } else {
+            values.push_back(std::stoi(token));
+        }
+
+        if (end == std::string::npos)
+            break;
+        start = end + 1;
+    }
+
+    if (values.empty() || !values.front())
+        return nullptr;
+
+    NodePtr root = make_node(*values.front());
+    std::queue<NodePtr> queue;
+    queue.push(root);
+
+    std::size_t index = 1;
+    while (!queue.empty() && index < values.size()) {
+        const auto current = queue.front();
+        queue.pop();
+
+        if (values[index]) {
+            current->left = make_node(*values[index]);
+            queue.push(current->left);
+        }
+        ++index;
+        if (index >= values.size())
+            break;
+
+        if (values[index]) {
+            current->right = make_node(*values[index]);
+            queue.push(current->right);
+        }
+        ++index;
+    }
+
+    return root;
+}
+
+inline NodePtr invert_tree(NodePtr root) {
+    if (!root)
+        return nullptr;
+
+    std::swap(root->left, root->right);
+    invert_tree(root->left);
+    invert_tree(root->right);
+    return root;
+}
+
+inline int max_depth(const NodePtr& root) {
+    if (!root)
+        return 0;
+
+    return 1 + std::max(max_depth(root->left), max_depth(root->right));
+}
+
+inline bool same_tree(const NodePtr& left, const NodePtr& right) {
+    if (!left || !right)
+        return !left && !right;
+
+    return left->value == right->value && same_tree(left->left, right->left) &&
+           same_tree(left->right, right->right);
+}
+
+inline bool is_subtree(const NodePtr& root, const NodePtr& sub) {
+    if (!sub)
+        return true;
+    if (!root)
+        return false;
+
+    if (same_tree(root, sub))
+        return true;
+
+    return is_subtree(root->left, sub) || is_subtree(root->right, sub);
+}
+
+inline NodePtr lowest_common_ancestor_bst(NodePtr root, int value1, int value2) {
+    while (root) {
+        if (value1 < root->value && value2 < root->value) {
+            root = root->left;
+        } else if (value1 > root->value && value2 > root->value) {
+            root = root->right;
+        } else {
+            return root;
+        }
+    }
+
+    return nullptr;
+}
+
+inline std::vector<std::vector<int>> level_order(const NodePtr& root) {
+    std::vector<std::vector<int>> levels;
+    if (!root)
+        return levels;
+
+    std::queue<NodePtr> queue;
+    queue.push(root);
+
+    while (!queue.empty()) {
+        const auto size = queue.size();
+        std::vector<int> level;
+        level.reserve(size);
+
+        for (std::size_t index = 0; index < size; ++index) {
+            const auto node = queue.front();
+            queue.pop();
+            level.push_back(node->value);
+
+            if (node->left)
+                queue.push(node->left);
+            if (node->right)
+                queue.push(node->right);
+        }
+
+        levels.push_back(std::move(level));
+    }
+
+    return levels;
+}
+
+inline bool is_valid_bst(const NodePtr& root, std::optional<int> min = std::nullopt,
+                         std::optional<int> max = std::nullopt) {
+    if (!root)
+        return true;
+
+    if ((min && root->value <= *min) || (max && root->value >= *max))
+        return false;
+
+    return is_valid_bst(root->left, min, root->value) &&
+           is_valid_bst(root->right, root->value, max);
+}
+
+inline std::optional<int> kth_smallest(const NodePtr& root, int k) {
+    std::vector<NodePtr> stack;
+    auto current = root;
+    int count = 0;
+
+    while (current || !stack.empty()) {
+        while (current) {
+            stack.push_back(current);
+            current = current->left;
+        }
+
+        current = stack.back();
+        stack.pop_back();
+        ++count;
+        if (count == k)
+            return current->value;
+
+        current = current->right;
+    }
+
+    return std::nullopt;
+}
+
+inline NodePtr build_tree_impl(const std::vector<int>& preorder, std::size_t pre_left,
+                               std::size_t pre_right,
+                               const std::unordered_map<int, std::size_t>& inorder_index,
+                               std::size_t in_left) {
+    if (pre_left > pre_right)
+        return nullptr;
+
+    const int root_value = preorder[pre_left];
+    const auto root = make_node(root_value);
+
+    const auto inorder_position = inorder_index.at(root_value);
+    const auto left_size = inorder_position - in_left;
+
+    root->left = build_tree_impl(preorder, pre_left + 1, pre_left + left_size, inorder_index,
+                                 in_left);
+    root->right = build_tree_impl(preorder, pre_left + left_size + 1, pre_right, inorder_index,
+                                  inorder_position + 1);
+
+    return root;
+}
+
+inline NodePtr build_tree(const std::vector<int>& preorder, const std::vector<int>& inorder) {
+    if (preorder.size() != inorder.size() || preorder.empty())
+        return nullptr;
+
+    std::unordered_map<int, std::size_t> inorder_index;
+    inorder_index.reserve(inorder.size());
+    for (std::size_t index = 0; index < inorder.size(); ++index)
+        inorder_index[inorder[index]] = index;
+
+    return build_tree_impl(preorder, 0, preorder.size() - 1, inorder_index, 0);
+}
+
+inline int max_path_sum_impl(const NodePtr& node, int& best) {
+    if (!node)
+        return 0;
+
+    const int left_gain = std::max(0, max_path_sum_impl(node->left, best));
+    const int right_gain = std::max(0, max_path_sum_impl(node->right, best));
+
+    best = std::max(best, node->value + left_gain + right_gain);
+    return node->value + std::max(left_gain, right_gain);
+}
+
+inline int max_path_sum(const NodePtr& root) {
+    int best = std::numeric_limits<int>::min();
+    max_path_sum_impl(root, best);
+    return best;
+}
+
+inline std::string describe_levels(const std::vector<std::vector<int>>& levels) {
+    std::ostringstream stream;
+    stream << '[';
+    for (std::size_t level_index = 0; level_index < levels.size(); ++level_index) {
+        if (level_index > 0)
+            stream << ", ";
+        stream << '[';
+        for (std::size_t value_index = 0; value_index < levels[level_index].size();
+             ++value_index) {
+            if (value_index > 0)
+                stream << ", ";
+            stream << levels[level_index][value_index];
+        }
+        stream << ']';
+    }
+    stream << ']';
+    return stream.str();
+}
+
+} // namespace qpp::examples::tree
+

--- a/examples/data-structures-and-algorithms/tree/tree_problems.qpp
+++ b/examples/data-structures-and-algorithms/tree/tree_problems.qpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <optional>
+#include <vector>
+
+#include "tree_problems.hpp"
+
+int main() {
+    using namespace qpp::examples::tree;
+
+    auto invert_example = make_tree({4, 2, 7, 1, 3, 6, 9});
+    std::cout << "Binary Tree Level Order Traversal\n  original: "
+              << describe_levels(level_order(invert_example)) << '\n';
+    invert_example = invert_tree(invert_example);
+    std::cout << "  inverted: " << describe_levels(level_order(invert_example))
+              << "\n\n";
+
+    auto depth_example = make_tree({3, 9, 20, std::nullopt, std::nullopt, 15, 7});
+    std::cout << "Maximum Depth of Binary Tree\n  depth: " << max_depth(depth_example)
+              << "\n\n";
+
+    auto same_tree_left = make_tree({1, 2, 3});
+    auto same_tree_right = make_tree({1, 2, 3});
+    std::cout << std::boolalpha;
+    std::cout << "Same Tree\n  equal: " << same_tree(same_tree_left, same_tree_right)
+              << "\n\n";
+
+    auto subtree_root = make_tree({3, 4, 5, 1, 2});
+    auto subtree_candidate = make_tree({4, 1, 2});
+    std::cout << "Subtree of Another Tree\n  is_subtree: "
+              << is_subtree(subtree_root, subtree_candidate) << "\n\n";
+
+    auto bst_example = make_tree({6, 2, 8, 0, 4, 7, 9, std::nullopt, std::nullopt, 3, 5});
+    const auto lca = lowest_common_ancestor_bst(bst_example, 2, 8);
+    std::cout << "Lowest Common Ancestor of a Binary Search Tree\n  lca(2, 8): "
+              << (lca ? lca->value : -1) << "\n\n";
+
+    auto level_order_example = make_tree({1, 2, 3, 4, std::nullopt, 5});
+    const auto levels = level_order(level_order_example);
+    std::cout << "Binary Tree Level Order Traversal\n  levels: "
+              << describe_levels(levels) << "\n\n";
+
+    auto valid_bst = make_tree({5, 3, 7, 2, 4, 6, 8});
+    auto invalid_bst = make_tree({5, 1, 4, std::nullopt, std::nullopt, 3, 6});
+    std::cout << "Validate Binary Search Tree\n  valid: " << is_valid_bst(valid_bst)
+              << "\n  invalid: " << is_valid_bst(invalid_bst) << "\n\n";
+
+    const auto kth = kth_smallest(valid_bst, 3);
+    std::cout << "Kth Smallest Element in a BST\n  k=3: "
+              << (kth ? std::to_string(*kth) : std::string{"not found"}) << "\n\n";
+
+    const std::vector<int> preorder{3, 9, 20, 15, 7};
+    const std::vector<int> inorder{9, 3, 15, 20, 7};
+    auto constructed = build_tree(preorder, inorder);
+    std::cout << "Construct Binary Tree From Preorder and Inorder Traversal\n  levels: "
+              << describe_levels(level_order(constructed)) << "\n\n";
+
+    auto max_path_example = make_tree({-10, 9, 20, std::nullopt, std::nullopt, 15, 7});
+    std::cout << "Binary Tree Maximum Path Sum\n  sum: " << max_path_sum(max_path_example)
+              << "\n\n";
+
+    auto serialize_example = make_tree({1, 2, 3, std::nullopt, std::nullopt, 4, 5});
+    const auto serialized = serialize(serialize_example);
+    std::cout << "Serialize and Deserialize Binary Tree\n  serialized: " << serialized
+              << '\n';
+    const auto deserialized = deserialize(serialized);
+    std::cout << "  deserialized levels: "
+              << describe_levels(level_order(deserialized)) << '\n';
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a reusable binary tree helper header implementing classic interview algorithms
- add a companion `.qpp` example that exercises the algorithms and prints illustrative output

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2dc4bd254832fb09518ac76f76234