### PR TITLE
Add heap-based median finder example

### DIFF
--- a/examples/data-structures-and-algorithms/heap/median_finder.hpp
+++ b/examples/data-structures-and-algorithms/heap/median_finder.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <queue>
+#include <stdexcept>
+#include <vector>
+
+namespace qpp::examples::heap {
+
+/// A streaming median data structure built on top of two heaps.
+class MedianFinder {
+  public:
+    MedianFinder() = default;
+
+    template <typename InputIt>
+    MedianFinder(InputIt first, InputIt last) {
+        for (; first != last; ++first)
+            addNum(*first);
+    }
+
+    MedianFinder(std::initializer_list<int> values)
+        : MedianFinder(values.begin(), values.end()) {}
+
+    /// Add a number from the stream to the data structure.
+    void addNum(int num) {
+        if (lower_half_.empty() || num <= lower_half_.top())
+            lower_half_.push(num);
+        else
+            upper_half_.push(num);
+
+        rebalance();
+    }
+
+    /// Return the median of all numbers seen so far.
+    [[nodiscard]] double findMedian() const {
+        if (lower_half_.empty() && upper_half_.empty())
+            throw std::logic_error("MedianFinder::findMedian: no numbers have been added");
+
+        if (lower_half_.size() == upper_half_.size())
+            return (static_cast<double>(lower_half_.top()) +
+                    static_cast<double>(upper_half_.top())) /
+                   2.0;
+
+        return (lower_half_.size() > upper_half_.size())
+                   ? static_cast<double>(lower_half_.top())
+                   : static_cast<double>(upper_half_.top());
+    }
+
+    /// Return the number of elements contained in the structure.
+    [[nodiscard]] std::size_t size() const noexcept {
+        return lower_half_.size() + upper_half_.size();
+    }
+
+  private:
+    void rebalance() {
+        if (lower_half_.size() > upper_half_.size() + 1) {
+            upper_half_.push(lower_half_.top());
+            lower_half_.pop();
+        } else if (upper_half_.size() > lower_half_.size() + 1) {
+            lower_half_.push(upper_half_.top());
+            upper_half_.pop();
+        }
+    }
+
+    std::priority_queue<int> lower_half_;
+    std::priority_queue<int, std::vector<int>, std::greater<>> upper_half_;
+};
+
+/// Compute the running median for each prefix of the input sequence.
+inline std::vector<double> compute_running_medians(
+    const std::vector<int>& values) {
+    MedianFinder finder;
+    std::vector<double> medians;
+    medians.reserve(values.size());
+
+    for (int value : values) {
+        finder.addNum(value);
+        medians.push_back(finder.findMedian());
+    }
+
+    return medians;
+}
+
+} // namespace qpp::examples::heap
+

--- a/examples/data-structures-and-algorithms/heap/median_finder.qpp
+++ b/examples/data-structures-and-algorithms/heap/median_finder.qpp
@@ -1,0 +1,33 @@
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+#include "median_finder.hpp"
+
+int main() {
+    using namespace qpp::examples::heap;
+
+    MedianFinder finder;
+    const std::vector<int> stream{1, 2, 3, 4, 5, 6};
+
+    std::cout << std::fixed << std::setprecision(1);
+    for (int value : stream) {
+        finder.addNum(value);
+        std::cout << "After adding " << value
+                  << ", median -> " << finder.findMedian() << "\n";
+    }
+
+    const MedianFinder seeded{10, 20, 30};
+    std::cout << "Seeded MedianFinder median -> " << seeded.findMedian() << "\n";
+
+    const std::vector<int> unsorted{5, 15, 1, 3};
+    const auto medians = compute_running_medians(unsorted);
+
+    std::cout << "Running medians for {5, 15, 1, 3}:\n";
+    for (std::size_t index = 0; index < medians.size(); ++index)
+        std::cout << "  prefix " << (index + 1) << " -> " << medians[index] << "\n";
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add a heap-based `MedianFinder` example that maintains a streaming median
- provide a helper to compute running medians for a sequence
- demonstrate usage in a corresponding `.qpp` example program

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4800562d4832fbe3cebd0f4e88898