### PR TITLE
Refactor backtracking examples to use quantum data structures

### DIFF
--- a/examples/data-structures-and-algorithms/backtracking/backtracking.hpp
+++ b/examples/data-structures-and-algorithms/backtracking/backtracking.hpp
@@ -2,19 +2,28 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <string>
 #include <string_view>
-#include <vector>
+#include <utility>
 
+#include "qpp/entangled_set"
 #include "qpp/pbool.h"
+#include "qpp/qstruct.hpp"
+#include "qpp/qvector"
 
 namespace qpp::examples::backtracking {
 namespace detail {
 
-inline void combination_sum_dfs(const std::vector<int>& candidates,
+inline std::size_t encode_position(std::size_t row, std::size_t col,
+                                   std::size_t cols) noexcept {
+    return row * cols + col;
+}
+
+inline void combination_sum_dfs(const std::qvector<int>& candidates,
                                 int target, std::size_t index,
-                                std::vector<int>& combination,
-                                std::vector<std::vector<int>>& result) {
+                                std::qvector<int>& combination,
+                                std::qvector<std::qvector<int>>& result) {
     if (target == 0) {
         result.push_back(combination);
         return;
@@ -31,9 +40,10 @@ inline void combination_sum_dfs(const std::vector<int>& candidates,
     }
 }
 
-inline bool word_search_dfs(const std::vector<std::vector<char>>& board,
+inline bool word_search_dfs(const std::qvector<std::qvector<char>>& board,
                             std::string_view word, std::size_t depth, int row,
-                            int col, std::vector<std::vector<bool>>& visited) {
+                            int col, std::entangled_set<std::size_t>& visited,
+                            std::size_t cols) {
     if (depth == word.size())
         return true;
 
@@ -49,14 +59,17 @@ inline bool word_search_dfs(const std::vector<std::vector<char>>& board,
         const std::size_t c = static_cast<std::size_t>(next_col);
         if (r >= board.size() || c >= board[r].size())
             continue;
-        if (visited[r][c] || board[r][c] != word[depth])
+        if (board[r][c] != word[depth])
             continue;
 
-        visited[r][c] = true;
-        if (word_search_dfs(board, word, depth + 1, next_row, next_col,
-                            visited))
+        const std::size_t key = encode_position(r, c, cols);
+        if (!visited.insert(key).second)
+            continue;
+
+        if (word_search_dfs(board, word, depth + 1, next_row, next_col, visited,
+                            cols))
             return true;
-        visited[r][c] = false;
+        visited.erase(key);
     }
 
     return false;
@@ -69,17 +82,21 @@ inline bool word_search_dfs(const std::vector<std::vector<char>>& board,
 /// The candidates are deduplicated and sorted internally. Each value can be
 /// used unlimited times. The algorithm performs a depth-first search while
 /// pruning branches whenever the partial sum would exceed the target.
-[[nodiscard]] inline std::vector<std::vector<int>>
-combination_sum(std::vector<int> candidates, int target) {
+[[nodiscard]] inline std::qvector<std::qvector<int>>
+combination_sum(std::qvector<int> candidates, int target) {
     if (target < 0)
         return {};
 
-    std::sort(candidates.begin(), candidates.end());
-    candidates.erase(std::unique(candidates.begin(), candidates.end()),
-                     candidates.end());
+    std::entangled_set<int> unique_candidates;
+    unique_candidates.reserve(candidates.size());
+    for (int value : candidates)
+        unique_candidates.insert(value);
 
-    std::vector<std::vector<int>> result;
-    std::vector<int> combination;
+    candidates.assign(unique_candidates.begin(), unique_candidates.end());
+    std::sort(candidates.begin(), candidates.end());
+
+    std::qvector<std::qvector<int>> result;
+    std::qvector<int> combination;
     detail::combination_sum_dfs(candidates, target, 0, combination, result);
     return result;
 }
@@ -89,7 +106,7 @@ combination_sum(std::vector<int> candidates, int target) {
 /// Returns `true` when the word can be formed without revisiting cells. The
 /// recursion explores neighbours starting from every matching cell on the grid.
 [[nodiscard]] inline bool word_search(
-    const std::vector<std::vector<char>>& board, std::string_view word) {
+    const std::qvector<std::qvector<char>>& board, std::string_view word) {
     if (word.empty())
         return true;
     if (board.empty() || board.front().empty())
@@ -98,18 +115,21 @@ combination_sum(std::vector<int> candidates, int target) {
     const std::size_t rows = board.size();
     const std::size_t cols = board.front().size();
 
-    std::vector<std::vector<bool>> visited(rows, std::vector<bool>(cols, false));
+    std::entangled_set<std::size_t> visited;
+    visited.reserve(rows * cols);
 
     for (std::size_t r = 0; r < rows; ++r) {
         for (std::size_t c = 0; c < cols; ++c) {
             if (board[r][c] != word.front())
                 continue;
-            visited[r][c] = true;
+            visited.clear();
+            const std::size_t key = detail::encode_position(r, c, cols);
+            visited.insert(key);
             if (detail::word_search_dfs(board, word, 1,
                                         static_cast<int>(r),
-                                        static_cast<int>(c), visited))
+                                        static_cast<int>(c), visited, cols))
                 return true;
-            visited[r][c] = false;
+            visited.erase(key);
         }
     }
 
@@ -120,8 +140,11 @@ combination_sum(std::vector<int> candidates, int target) {
 /// is primarily useful when integrating classical search results with quantum
 /// control logic inside QPP examples.
 [[nodiscard]] inline qpp::pbool word_search_probability(
-    const std::vector<std::vector<char>>& board, std::string_view word) {
-    return qpp::pbool(word_search(board, word) ? 1.0 : 0.0);
+    const std::qvector<std::qvector<char>>& board, std::string_view word) {
+    qpp::qclass indicator(1);
+    if (word_search(board, word))
+        indicator.apply_x(0);
+    return indicator.data().measure(0);
 }
 
 } // namespace qpp::examples::backtracking

--- a/examples/data-structures-and-algorithms/backtracking/backtracking.qpp
+++ b/examples/data-structures-and-algorithms/backtracking/backtracking.qpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-void print_combinations(const std::vector<std::vector<int>>& combos) {
+void print_combinations(const std::qvector<std::qvector<int>>& combos) {
     std::cout << "Found " << combos.size() << " combinations:\n";
     for (const auto& combo : combos) {
         std::cout << "  [";
@@ -20,7 +20,7 @@ void print_combinations(const std::vector<std::vector<int>>& combos) {
     }
 }
 
-void print_board(const std::vector<std::vector<char>>& board) {
+void print_board(const std::qvector<std::qvector<char>>& board) {
     std::cout << "Board:\n";
     for (const auto& row : board) {
         for (char cell : row)
@@ -34,15 +34,15 @@ void print_board(const std::vector<std::vector<char>>& board) {
 int main() {
     using namespace qpp::examples::backtracking;
 
-    const std::vector<int> candidates{2, 3, 6, 7};
+    const std::qvector<int> candidates{2, 3, 6, 7};
     const int target = 7;
     std::cout << "combination_sum([2,3,6,7], 7)\n";
     auto combos = combination_sum(candidates, target);
     print_combinations(combos);
 
-    std::vector<std::vector<char>> board{{'A', 'B', 'C', 'E'},
-                                         {'S', 'F', 'C', 'S'},
-                                         {'A', 'D', 'E', 'E'}};
+    std::qvector<std::qvector<char>> board{{'A', 'B', 'C', 'E'},
+                                           {'S', 'F', 'C', 'S'},
+                                           {'A', 'D', 'E', 'E'}};
     print_board(board);
 
     const std::string word1 = "ABCCED";


### PR DESCRIPTION
## Summary
- switch the backtracking helpers to use `std::qvector` containers and entangled sets for visited state tracking
- derive probabilistic results through a one-qubit `qpp::qclass` register to expose a quantum data flow
- update the accompanying example driver to consume the revised quantum-friendly interfaces

## Testing
- not run (QA scope)


------
https://chatgpt.com/codex/tasks/task_e_68ef665ee780832fa63678242314c542