### PR TITLE
Streamline duplicate detection API

### DIFF
--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
@@ -88,11 +88,6 @@ int main() {
 
     std::cout << std::boolalpha;
 
-    // Classical demonstrations
-    const std::vector<int> duplicate_input{1, 2, 3, 1};
-    std::cout << "contains_duplicates([1,2,3,1]) -> "
-              << contains_duplicates(duplicate_input) << '\n';
-
     const std::qvector<::qint> quantum_duplicate_input{
         ::qint{1, -1, 1, -1},
         ::qint{-3, 5, -7, 9},
@@ -103,10 +98,10 @@ int main() {
         ::qint{4, 0, 4, 0},
         ::qint{7, 7, -3, -3},
     };
-    std::cout << "quantum_contains_duplicates([...duplicate...]) -> "
-              << quantum_contains_duplicates(quantum_duplicate_input) << '\n';
-    std::cout << "quantum_contains_duplicates([...unique...]) -> "
-              << quantum_contains_duplicates(quantum_unique_input) << '\n';
+    std::cout << "contains_duplicates([...duplicate...]) -> "
+              << contains_duplicates(quantum_duplicate_input) << '\n';
+    std::cout << "contains_duplicates([...unique...]) -> "
+              << contains_duplicates(quantum_unique_input) << '\n';
 
     std::cout << "valid_anagram('listen','silent') -> "
               << valid_anagram("listen", "silent") << '\n';


### PR DESCRIPTION
## Summary
- keep only the quantum-oriented `contains_duplicates` implementation and drop the extra helper
- update the example program to invoke `contains_duplicates` for the quantum duplicate demonstrations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef6a01a660832f8b623ea83e03f1bf