### PR TITLE
Refactor bit manipulation helpers to use measurement APIs

### DIFF
--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -11,9 +12,93 @@
 
 namespace qpp::examples::bit_manipulation {
 
-/// Count the number of set bits for a quantum integer by delegating to the
-/// classical counterpart.
-inline int hamming_weight(const qint& value) {
+namespace detail {
+
+inline constexpr unsigned quantum_bit_width = 4U;
+inline constexpr std::uint32_t quantum_mask = (1u << quantum_bit_width) - 1u;
+
+inline int orientation_to_bit(int orientation) noexcept { return orientation > 0 ? 1 : 0; }
+
+inline int bit_to_orientation(unsigned bit) noexcept { return bit ? 1 : -1; }
+
+inline std::array<int, quantum_bit_width> sample_axes(const qint& value) {
+    return {value.x_step().sample(), value.y_step().sample(), value.z_step().sample(),
+            value.t_step().sample()};
+}
+
+inline std::uint32_t axes_to_bits(const std::array<int, quantum_bit_width>& axes) noexcept {
+    std::uint32_t bits = 0;
+    for (int orientation : axes) {
+        bits <<= 1U;
+        bits |= static_cast<std::uint32_t>(orientation_to_bit(orientation));
+    }
+    return bits;
+}
+
+inline std::uint32_t collapse_to_bits(const qint& value) {
+    return axes_to_bits(sample_axes(value));
+}
+
+inline std::array<int, quantum_bit_width> bits_to_axes(std::uint32_t bits) noexcept {
+    std::array<int, quantum_bit_width> axes{};
+    for (std::size_t axis = 0; axis < axes.size(); ++axis) {
+        const std::size_t shift = axes.size() - axis - 1U;
+        axes[axis] = bit_to_orientation((bits >> shift) & 0x1u);
+    }
+    return axes;
+}
+
+inline qint build_from_bits(std::uint32_t bits) {
+    const auto axes = bits_to_axes(bits & quantum_mask);
+    return qint(axes[0], axes[1], axes[2], axes[3]);
+}
+
+inline int collapse_to_signed(const qint& value) {
+    const std::uint32_t bits = collapse_to_bits(value);
+    const std::uint32_t sign_mask = 1u << (quantum_bit_width - 1U);
+    if (bits & sign_mask) {
+        const std::int32_t extended = static_cast<std::int32_t>(bits | (~quantum_mask));
+        return static_cast<int>(extended);
+    }
+    return static_cast<int>(bits);
+}
+
+inline qint build_from_signed(int value) {
+    const std::uint32_t bits = static_cast<std::uint32_t>(value) & quantum_mask;
+    return build_from_bits(bits);
+}
+
+inline std::vector<int> collapse_vector(const std::qvector<qint>& values) {
+    std::vector<int> result;
+    result.reserve(values.size());
+    for (const auto& value : values)
+        result.push_back(collapse_to_signed(value));
+    return result;
+}
+
+inline std::qvector<qint> build_vector(const std::vector<int>& values) {
+    std::qvector<qint> result;
+    result.reserve(values.size());
+    for (int value : values)
+        result.push_back(build_from_signed(value));
+    return result;
+}
+
+inline std::uint32_t reverse_bits_with_width(std::uint32_t bits, unsigned width) noexcept {
+    std::uint32_t reversed = 0;
+    for (unsigned i = 0; i < width; ++i) {
+        reversed <<= 1U;
+        reversed |= (bits >> i) & 0x1u;
+    }
+    return reversed;
+}
+
+} // namespace detail
+
+inline constexpr unsigned quantum_bit_width = detail::quantum_bit_width;
+
+/// Count the number of set bits for a classical integer.
+inline int hamming_weight(std::uint32_t value) {
     int count = 0;
     while (value != 0U) {
         value &= value - 1U;
@@ -22,21 +107,30 @@ inline int hamming_weight(const qint& value) {
     return count;
 }
 
+/// Count the number of set bits for a quantum integer by collapsing to the classical domain.
+inline int hamming_weight(const qint& value) {
+    return hamming_weight(detail::collapse_to_bits(value));
+}
 
-/// Compute population counts for the range [0, n] and encode them as quantum
-/// integers.
-inline std::qvector<qint> counting_bits(int n) {
-    const auto classical = counting_bits(n);
-    std::qvector<qint> result;
-    result.reserve(classical.size());
-    for (int value : classical)
-        result.push_back(static_cast<qint>(value));
+/// Compute population counts for the range [0, n] (classical).
+inline std::vector<int> counting_bits(int n) {
+    if (n < 0)
+        return {};
+
+    std::vector<int> result(static_cast<std::size_t>(n) + 1);
+    for (int i = 0; i <= n; ++i)
+        result[static_cast<std::size_t>(i)] =
+            hamming_weight(static_cast<std::uint32_t>(i));
     return result;
 }
 
+/// Compute population counts for the range [0, n] and encode them as quantum integers.
+inline std::qvector<qint> quantum_counting_bits(int n) {
+    return detail::build_vector(counting_bits(n));
+}
 
-/// Reverse the bits of a quantum integer treated as a 32-bit value.
-inline qint reverse_bits(const qint& value) {
+/// Reverse the bits of a 32-bit classical value.
+inline std::uint32_t reverse_bits(std::uint32_t value) {
     value = ((value & 0x55555555u) << 1U) | ((value >> 1U) & 0x55555555u);
     value = ((value & 0x33333333u) << 2U) | ((value >> 2U) & 0x33333333u);
     value = ((value & 0x0F0F0F0Fu) << 4U) | ((value >> 4U) & 0x0F0F0F0Fu);
@@ -45,29 +139,65 @@ inline qint reverse_bits(const qint& value) {
     return value;
 }
 
+/// Reverse the bits stored within a quantum integer.
+inline qint reverse_bits(const qint& value) {
+    const std::uint32_t bits = detail::collapse_to_bits(value);
+    const std::uint32_t reversed =
+        detail::reverse_bits_with_width(bits, detail::quantum_bit_width);
+    return detail::build_from_bits(reversed);
+}
 
-/// Return the missing value in the quantum variant of the problem.
-inline qint missing_number(const std::qvector<qint>& nums) {
-    std::vector<int> classical;
-    classical.reserve(nums.size());
-    for (const auto& value : nums)
-        classical.push_back(static_cast<int>(value));
-    int xor_accumulator = static_cast<int>(classical.size());
-    for (std::size_t i = 0; i < classical.size(); ++i) {
+/// Return the missing value in the classical variant of the problem.
+inline int missing_number(const std::vector<int>& nums) {
+    int xor_accumulator = static_cast<int>(nums.size());
+    for (std::size_t i = 0; i < nums.size(); ++i) {
         xor_accumulator ^= static_cast<int>(i);
-        xor_accumulator ^= classical[i];
+        xor_accumulator ^= nums[i];
     }
     return xor_accumulator;
 }
 
-/// Compute the bitwise sum of two quantum integers.
-inline qint sum_two_integers(const qint& a, const qint& b) {
+/// Return the missing value in the quantum variant of the problem.
+inline qint missing_number(const std::qvector<qint>& nums) {
+    const auto classical = detail::collapse_vector(nums);
+    return detail::build_from_signed(missing_number(classical));
+}
+
+/// Compute the bitwise sum of two classical integers without using the + operator.
+inline int sum_two_integers(int a, int b) {
     while (b != 0) {
-        const int carry = (a & b) << 1U;
+        const unsigned carry = static_cast<unsigned>(a & b) << 1U;
         a ^= b;
-        b = carry;
+        b = static_cast<int>(carry);
     }
     return a;
+}
+
+/// Compute the bitwise sum of two quantum integers.
+inline qint sum_two_integers(const qint& a, const qint& b) {
+    const int lhs = detail::collapse_to_signed(a);
+    const int rhs = detail::collapse_to_signed(b);
+    return detail::build_from_signed(sum_two_integers(lhs, rhs));
+}
+
+/// Convenience wrapper for converting a classical unsigned value into a quantum integer.
+inline qint make_quantum_from_uint32(std::uint32_t value) {
+    return detail::build_from_bits(value);
+}
+
+/// Convenience wrapper for converting a classical signed value into a quantum integer.
+inline qint make_quantum_from_int(int value) {
+    return detail::build_from_signed(value);
+}
+
+/// Collapse a quantum integer into its unsigned classical representation.
+inline std::uint32_t collapse_quantum_to_uint32(const qint& value) {
+    return detail::collapse_to_bits(value);
+}
+
+/// Collapse a quantum integer into its signed classical representation.
+inline int collapse_quantum_to_int(const qint& value) {
+    return detail::collapse_to_signed(value);
 }
 
 /// Probability wrapper describing whether a value has even parity.
@@ -82,6 +212,19 @@ inline qpp::qclass make_uniform_bit_superposition(std::size_t bit_width) {
     for (std::size_t q = 0; q < bit_width; ++q)
         reg.apply_h(q);
     return reg;
+}
+
+/// Convenience wrappers mirroring the quantum-prefixed APIs used by the sample.
+inline int quantum_hamming_weight(const qint& value) { return hamming_weight(value); }
+
+inline qint quantum_reverse_bits(const qint& value) { return reverse_bits(value); }
+
+inline qint quantum_missing_number(const std::qvector<qint>& nums) {
+    return missing_number(nums);
+}
+
+inline qint quantum_sum_two_integers(const qint& a, const qint& b) {
+    return sum_two_integers(a, b);
 }
 
 } // namespace qpp::examples::bit_manipulation

--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <iostream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "bit_manipulation.hpp"
@@ -26,14 +27,16 @@ void print_state(const qpp::qstruct& state, const std::string& label) {
     }
 }
 
-int as_classical(const ::qint& value) {
-    auto stats = value.measure_register();
-    int result = 0;
-    for (std::size_t axis = 0; axis < stats.size(); ++axis) {
-        result <<= 1;
-        result |= stats[axis].collapsed_value.value_or(0) == 1 ? 1 : 0;
+
+template <typename T, typename U>
+void expect_equal(std::string_view label, const T& expected, const U& actual, bool& passed) {
+    if (expected != actual) {
+        passed = false;
+        std::cout << "[FAIL] " << label << ": expected " << expected << ", got " << actual
+                  << '\n';
+    } else {
+        std::cout << "[PASS] " << label << ": " << actual << '\n';
     }
-    return result;
 }
 } // namespace
 
@@ -42,63 +45,87 @@ int main() {
 
     std::cout << std::boolalpha;
 
-    const std::uint32_t sample = 0b101101001u;
-    std::cout << "hamming_weight(0b101101001) -> " << hamming_weight(sample) << '\n';
-    std::cout << "reverse_bits(0b101101001) -> 0b"
-              << std::bitset<32>(reverse_bits(sample)) << '\n';
+    bool all_passed = true;
 
-    const auto counts = counting_bits(10);
-    std::cout << "counting_bits(10) -> [";
-    for (std::size_t i = 0; i < counts.size(); ++i) {
-        std::cout << counts[i];
-        if (i + 1 != counts.size())
+    const std::uint32_t sample = 0b1011u;
+    const auto quantum_sample = make_quantum_from_uint32(sample);
+
+    const int classical_hw = hamming_weight(sample);
+    const int quantum_hw = hamming_weight(quantum_sample);
+    std::cout << "hamming_weight(0b" << std::bitset<4>(sample) << ") -> " << classical_hw
+              << '\n';
+    expect_equal("quantum hamming_weight matches classical", classical_hw, quantum_hw,
+                 all_passed);
+
+    const std::uint32_t classical_reversed = reverse_bits(sample);
+    std::cout << "reverse_bits(0b" << std::bitset<4>(sample) << ") -> 0b"
+              << std::bitset<32>(classical_reversed) << '\n';
+    const std::uint32_t quantum_reversed_nibble =
+        collapse_quantum_to_uint32(reverse_bits(quantum_sample));
+    const std::uint32_t expected_nibble =
+        classical_reversed >> (32U - quantum_bit_width);
+    expect_equal("quantum reverse_bits nibble", expected_nibble, quantum_reversed_nibble,
+                 all_passed);
+
+    const auto classical_counts = counting_bits(5);
+    std::cout << "counting_bits(5) -> [";
+    for (std::size_t i = 0; i < classical_counts.size(); ++i) {
+        std::cout << classical_counts[i];
+        if (i + 1 != classical_counts.size())
             std::cout << ", ";
     }
     std::cout << "]\n";
+    const auto quantum_counts = quantum_counting_bits(5);
+    bool counts_match = classical_counts.size() == quantum_counts.size();
+    std::vector<int> collapsed_quantum_counts;
+    collapsed_quantum_counts.reserve(quantum_counts.size());
+    for (std::size_t i = 0; i < quantum_counts.size(); ++i) {
+        const int collapsed = collapse_quantum_to_int(quantum_counts[i]);
+        collapsed_quantum_counts.push_back(collapsed);
+        if (counts_match && classical_counts[i] != collapsed)
+            counts_match = false;
+    }
+    std::cout << "quantum_counting_bits(5) -> [";
+    for (std::size_t i = 0; i < collapsed_quantum_counts.size(); ++i) {
+        std::cout << collapsed_quantum_counts[i];
+        if (i + 1 != collapsed_quantum_counts.size())
+            std::cout << ", ";
+    }
+    std::cout << "]\n";
+    expect_equal("quantum counting_bits sequence", true, counts_match, all_passed);
 
     const std::vector<int> missing_input{3, 0, 1};
-    std::cout << "missing_number([3,0,1]) -> " << missing_number(missing_input) << '\n';
-    std::cout << "sum_two_integers(5, -3) -> " << sum_two_integers(5, -3) << '\n';
-
-    const std::qvector<::qint> quantum_values{
-        static_cast<::qint>(sample),
-    };
-    std::cout << "quantum_hamming_weight(0b101101001) -> "
-              << quantum_hamming_weight(quantum_values.front()) << '\n';
-    std::cout << "quantum_reverse_bits(0b101101001) -> 0b"
-              << std::bitset<32>(static_cast<std::uint32_t>(
-                     static_cast<int>(quantum_reverse_bits(quantum_values.front()))))
-              << '\n';
-
-    const auto quantum_counts = quantum_counting_bits(5);
-    std::cout << "quantum_counting_bits(5) -> [";
-    for (std::size_t i = 0; i < quantum_counts.size(); ++i) {
-        std::cout << as_classical(quantum_counts[i]);
-        if (i + 1 != quantum_counts.size())
-            std::cout << ", ";
-    }
-    std::cout << "]\n";
-
+    const int classical_missing = missing_number(missing_input);
+    std::cout << "missing_number([3,0,1]) -> " << classical_missing << '\n';
     const std::qvector<::qint> quantum_missing{
-        static_cast<::qint>(3),
-        static_cast<::qint>(0),
-        static_cast<::qint>(1),
+        make_quantum_from_int(3),
+        make_quantum_from_int(0),
+        make_quantum_from_int(1),
     };
-    std::cout << "quantum_missing_number([3,0,1]) -> "
-              << as_classical(quantum_missing_number(quantum_missing)) << '\n';
+    const int quantum_missing_value =
+        collapse_quantum_to_int(quantum_missing_number(quantum_missing));
+    expect_equal("quantum missing_number", classical_missing, quantum_missing_value,
+                 all_passed);
 
-    std::cout << "quantum_sum_two_integers(5, -3) -> "
-              << as_classical(quantum_sum_two_integers(static_cast<::qint>(5),
-                                                       static_cast<::qint>(-3)))
-              << '\n';
+    const int classical_sum = sum_two_integers(5, -3);
+    std::cout << "sum_two_integers(5, -3) -> " << classical_sum << '\n';
+    const int quantum_sum_value = collapse_quantum_to_int(
+        quantum_sum_two_integers(make_quantum_from_int(5), make_quantum_from_int(-3)));
+    expect_equal("quantum sum_two_integers", classical_sum, quantum_sum_value, all_passed);
 
     auto superposition = make_uniform_bit_superposition(3);
     print_state(superposition.data(), "Uniform bit superposition for 3 qubits");
 
+    const double parity_probability = even_parity_probability(sample).probability();
     std::cout << std::setprecision(3)
-              << "even_parity_probability(0b101101001) -> "
-              << even_parity_probability(sample).probability() << '\n';
+              << "even_parity_probability(0b" << std::bitset<4>(sample) << ") -> "
+              << parity_probability << '\n';
+    expect_equal("even parity probability",
+                 (classical_hw % 2 == 0) ? 1.0 : 0.0, parity_probability, all_passed);
 
-    return 0;
+    if (!all_passed)
+        std::cout << "One or more quantum validations diverged from the classical results.\n";
+
+    return all_passed ? 0 : 1;
 }
 


### PR DESCRIPTION
## Summary
- add measurement-based conversion helpers and classical overloads for the bit manipulation algorithms
- update the bit manipulation example to validate the quantum wrappers against classical results

## Testing
- g++ -std=c++20 -x c++ -Iinclude -I. examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp -o /tmp/bit_example
- /tmp/bit_example

------
https://chatgpt.com/codex/tasks/task_e_68efe1916428832f81863c44d38a7fb3