### PR TITLE
Add classical overloads for bit manipulation quantum helpers

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -31,3 +31,8 @@ add_example(bell_state ../qpp/backend/LocalSimBackend.cpp)
 add_example(hardware_demo ../qpp/backend/LocalSimBackend.cpp ../qpp/backend/QPUBackend.cpp)
 add_example(hardware_api_example)
 add_example(master_demo ../qpp/backend/LocalSimBackend.cpp)
+
+set(bit_manipulation_src
+    ${CMAKE_CURRENT_SOURCE_DIR}/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp)
+set_source_files_properties(${bit_manipulation_src} PROPERTIES LANGUAGE CXX COMPILE_FLAGS "-x c++")
+add_executable(bit_manipulation ${bit_manipulation_src})

--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
@@ -131,8 +131,10 @@ inline std::qvector<qint> counting_bits(int n) {
 }
 
 /// Compute population counts for the range [0, n] and encode them as quantum integers.
-inline std::qvector<qint> quantum_counting_bits(int n) {
-    return counting_bits(n);
+inline std::qvector<qint> quantum_counting_bits(int n) { return counting_bits(n); }
+
+inline std::qvector<qint> quantum_counting_bits(std::uint32_t n) {
+    return quantum_counting_bits(static_cast<int>(n));
 }
 
 /// Reverse the bits of a 32-bit classical value.
@@ -223,14 +225,34 @@ inline qpp::qclass make_uniform_bit_superposition(std::size_t bit_width) {
 /// Convenience wrappers mirroring the quantum-prefixed APIs used by the sample.
 inline int quantum_hamming_weight(const qint& value) { return hamming_weight(value); }
 
+inline int quantum_hamming_weight(std::uint32_t value) {
+    return quantum_hamming_weight(make_quantum_from_uint32(value));
+}
+
 inline qint quantum_reverse_bits(const qint& value) { return reverse_bits(value); }
+
+inline qint quantum_reverse_bits(std::uint32_t value) {
+    return quantum_reverse_bits(make_quantum_from_uint32(value));
+}
 
 inline qint quantum_missing_number(const std::qvector<qint>& nums) {
     return missing_number(nums);
 }
 
+inline qint quantum_missing_number(const std::vector<int>& nums) {
+    return quantum_missing_number(detail::build_vector(nums));
+}
+
 inline qint quantum_sum_two_integers(const qint& a, const qint& b) {
     return sum_two_integers(a, b);
+}
+
+inline qint quantum_sum_two_integers(int a, int b) {
+    return quantum_sum_two_integers(make_quantum_from_int(a), make_quantum_from_int(b));
+}
+
+inline qint quantum_sum_two_integers(std::uint32_t a, std::uint32_t b) {
+    return quantum_sum_two_integers(make_quantum_from_uint32(a), make_quantum_from_uint32(b));
 }
 
 } // namespace qpp::examples::bit_manipulation

--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.qpp
@@ -48,10 +48,9 @@ int main() {
     bool all_passed = true;
 
     const std::uint32_t sample = 0b1011u;
-    const auto quantum_sample = make_quantum_from_uint32(sample);
 
     const int classical_hw = hamming_weight(sample);
-    const int quantum_hw = hamming_weight(quantum_sample);
+    const int quantum_hw = quantum_hamming_weight(sample);
     std::cout << "hamming_weight(0b" << std::bitset<4>(sample) << ") -> " << classical_hw
               << '\n';
     expect_equal("quantum hamming_weight matches classical", classical_hw, quantum_hw,
@@ -61,7 +60,7 @@ int main() {
     std::cout << "reverse_bits(0b" << std::bitset<4>(sample) << ") -> 0b"
               << std::bitset<32>(classical_reversed) << '\n';
     const std::uint32_t quantum_reversed_nibble =
-        collapse_quantum_to_uint32(reverse_bits(quantum_sample));
+        collapse_quantum_to_uint32(quantum_reverse_bits(sample));
     const std::uint32_t expected_nibble =
         classical_reversed >> (32U - quantum_bit_width);
     expect_equal("quantum reverse_bits nibble", expected_nibble, quantum_reversed_nibble,
@@ -75,7 +74,7 @@ int main() {
             std::cout << ", ";
     }
     std::cout << "]\n";
-    const auto quantum_counts = counting_bits(5);
+    const auto quantum_counts = quantum_counting_bits(5);
     bool counts_match = classical_counts.size() == quantum_counts.size();
     std::vector<int> collapsed_quantum_counts;
     collapsed_quantum_counts.reserve(quantum_counts.size());
@@ -108,20 +107,15 @@ int main() {
     const std::vector<int> missing_input{3, 0, 1};
     const int classical_missing = missing_number(missing_input);
     std::cout << "missing_number([3,0,1]) -> " << classical_missing << '\n';
-    const std::qvector<::qint> quantum_missing{
-        make_quantum_from_int(3),
-        make_quantum_from_int(0),
-        make_quantum_from_int(1),
-    };
     const int quantum_missing_value =
-        collapse_quantum_to_int(quantum_missing_number(quantum_missing));
+        collapse_quantum_to_int(quantum_missing_number(missing_input));
     expect_equal("quantum missing_number", classical_missing, quantum_missing_value,
                  all_passed);
 
     const int classical_sum = sum_two_integers(5, -3);
     std::cout << "sum_two_integers(5, -3) -> " << classical_sum << '\n';
-    const int quantum_sum_value = collapse_quantum_to_int(
-        quantum_sum_two_integers(make_quantum_from_int(5), make_quantum_from_int(-3)));
+    const int quantum_sum_value =
+        collapse_quantum_to_int(quantum_sum_two_integers(5, -3));
     expect_equal("quantum sum_two_integers", classical_sum, quantum_sum_value, all_passed);
 
     auto superposition = make_uniform_bit_superposition(3);


### PR DESCRIPTION
## Summary
- add classical overloads for the quantum bit manipulation helper APIs and reuse them in the sample
- wire the bit manipulation example into the examples CMake project so it is built with the rest of the samples

## Testing
- cmake -S examples -B build/examples
- cmake --build build/examples --target bit_manipulation
- ./build/examples/bit_manipulation

------
https://chatgpt.com/codex/tasks/task_e_68eff90a00f0832f9f8c3797247c0fa7