### PR TITLE
Refactor dynamic programming demo to use qpp structures

### DIFF
--- a/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.hpp
+++ b/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.hpp
@@ -1,34 +1,59 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <string>
 #include <string_view>
-#include <vector>
+
+#include "qpp/pbool.h"
+#include "qpp/qstruct.hpp"
+#include "qpp/qvector"
+#include "qpp/quantum_dp.hpp"
 
 namespace qpp::examples::dynamic_programming_2d {
 
 /// Count the number of unique paths from the top-left to the bottom-right of an
-/// m x n grid when you may only move right or down.
-inline int unique_paths(int m, int n) {
+/// m x n grid when you may only move right or down. The classical count is
+/// represented as a probabilistic qpp::pbool value to integrate with quantum
+/// aware APIs.
+inline qpp::pbool unique_paths(int m, int n) {
     if (m <= 0 || n <= 0)
-        return 0;
-    std::vector<int> dp(static_cast<std::size_t>(n), 1);
+        return qpp::pbool{0.0};
+
+    std::qvector<int> dp(static_cast<std::size_t>(n), 1);
     for (int row = 1; row < m; ++row) {
         for (int col = 1; col < n; ++col)
             dp[static_cast<std::size_t>(col)] +=
                 dp[static_cast<std::size_t>(col - 1)];
     }
-    return dp.back();
+
+    const int classical_paths = dp.back();
+    const qpp::qdp::quantum_scalar<int> quantum_paths(classical_paths);
+
+    const int steps = m + n - 2;
+    const double total_sequences = steps <= 0 ? 1.0 : std::pow(2.0, steps);
+    const double probability = total_sequences > 0.0
+                                   ? static_cast<double>(quantum_paths.value()) /
+                                         total_sequences
+                                   : 0.0;
+
+    return qpp::pbool{probability};
 }
 
 /// Compute the longest common subsequence shared by two input strings using a
-/// classic dynamic programming table.
-inline std::string longest_common_subsequence(std::string_view first,
-                                              std::string_view second) {
+/// classic dynamic programming table but surfaced as a qpp::qdp::quantum_string
+/// so callers may inspect either the classical characters or the quantum
+/// amplitudes.
+inline qpp::qdp::quantum_string
+longest_common_subsequence(std::string_view first, std::string_view second) {
     const std::size_t rows = first.size();
     const std::size_t cols = second.size();
-    std::vector<std::vector<int>> dp(rows + 1, std::vector<int>(cols + 1, 0));
+
+    std::qvector<qpp::qdp::quantum_sequence<int>> dp;
+    dp.reserve(rows + 1);
+    for (std::size_t i = 0; i <= rows; ++i)
+        dp.emplace_back(cols + 1, 0);
 
     for (std::size_t i = 1; i <= rows; ++i) {
         for (std::size_t j = 1; j <= cols; ++j) {
@@ -37,6 +62,7 @@ inline std::string longest_common_subsequence(std::string_view first,
             else
                 dp[i][j] = std::max(dp[i - 1][j], dp[i][j - 1]);
         }
+        dp[i].refresh_state();
     }
 
     std::string result;
@@ -55,7 +81,10 @@ inline std::string longest_common_subsequence(std::string_view first,
         }
     }
     std::reverse(result.begin(), result.end());
-    return result;
+
+    qpp::qdp::quantum_string quantum_result(result);
+    quantum_result.refresh_state();
+    return quantum_result;
 }
 
 } // namespace qpp::examples::dynamic_programming_2d

--- a/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.qpp
+++ b/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.qpp
@@ -9,12 +9,15 @@ int main() {
     std::cout << "Dynamic Programming (2D) demonstrations\n";
     std::cout << "-------------------------------------\n";
 
-    std::cout << "unique_paths(3, 7) -> " << unique_paths(3, 7) << '\n';
+    const auto unique_result = unique_paths(3, 7);
+    std::cout << "unique_paths(3, 7) probability -> "
+              << unique_result.probability() << '\n';
 
     const std::string first = "abcde";
     const std::string second = "ace";
+    const auto lcs = longest_common_subsequence(first, second);
     std::cout << "longest_common_subsequence('" << first << "', '" << second
-              << "') -> '" << longest_common_subsequence(first, second) << "'\n";
+              << "') -> '" << lcs.to_std_string() << "'\n";
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- include qpp quantum headers in the dynamic programming example so the algorithms use quantum-aware facilities
- convert the unique path counter to operate on a qvector row buffer and return a probabilistic qpp::pbool result
- rebuild the LCS routine on quantum sequences and surface the answer as a qpp quantum string, updating the demo accordingly

## Testing
- `g++ -std=c++20 -Iinclude -x c++ examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.qpp -o /tmp/dp2d`
- `/tmp/dp2d`


------
https://chatgpt.com/codex/tasks/task_e_68effeff7988832fbe0b491b6f218efc