### PR TITLE
Include qint and qvector in greedy header

### DIFF
--- a/examples/data-structures-and-algorithms/greedy/greedy.hpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.hpp
@@ -6,7 +6,9 @@
 #include <cmath>
 #include <vector>
 
+#include "qpp/qint"
 #include "qpp/qstruct.hpp"
+#include "qpp/qvector"
 
 namespace qpp::examples::greedy {
 


### PR DESCRIPTION
## Summary
- include qpp/qint and qpp/qvector so the greedy example can use qint and std::qvector

## Testing
- cmake -S examples -B build/examples
- cmake --build build/examples

------
https://chatgpt.com/codex/tasks/task_e_68f00b699894832fb6a3380bb9d30683