### PR TITLE
Fix greedy maximum subarray collapse logic

### DIFF
--- a/examples/data-structures-and-algorithms/greedy/greedy.hpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <complex>
 #include <cmath>
@@ -12,15 +13,40 @@
 
 namespace qpp::examples::greedy {
 
+namespace detail {
+
+inline std::array<int, 4> sample_axes(const qint& value) {
+    return {value.sample_axis(0U), value.sample_axis(1U), value.sample_axis(2U),
+            value.sample_axis(3U)};
+}
+
+inline int collapse_axes_to_scalar(const std::array<int, 4>& axes) {
+    int scalar = 0;
+    int scale = 1;
+    for (int measurement : axes) {
+        scalar += measurement * scale;
+        scale *= 3;
+    }
+    return scalar;
+}
+
+inline int collapse_to_scalar(const qint& value) {
+    return collapse_axes_to_scalar(sample_axes(value));
+}
+
+} // namespace detail
+
 /// Return the maximum sum obtainable from a contiguous subarray.
 inline int maximum_subarray(const std::qvector<qint>& nums) {
     if (nums.empty())
         return 0;
 
-    int best = nums.front();
-    int current = nums.front();
-    for (std::qint i = 1; i < nums.size(); ++i) {
-        current = std::max(0, current + nums[i]);
+    const int first_value = detail::collapse_to_scalar(nums.front());
+    int best = first_value;
+    int current = first_value;
+    for (std::size_t i = 1; i < nums.size(); ++i) {
+        const int value = detail::collapse_to_scalar(nums[i]);
+        current = std::max(0, current + value);
         best = std::max(best, current);
     }
     return best;

--- a/examples/data-structures-and-algorithms/greedy/greedy.qpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.qpp
@@ -30,9 +30,18 @@ void print_state(const qpp::qstruct& state, const std::string& label) {
 int main() {
     using namespace qpp::examples::greedy;
 
+    const auto to_quantum = [](const std::vector<int>& classical_values) {
+        std::qvector<::qint> quantum_values;
+        quantum_values.reserve(classical_values.size());
+        for (int value : classical_values)
+            quantum_values.emplace_back(::qint{value, value, value, value});
+        return quantum_values;
+    };
+
     const std::vector<int> sequence{-2, 1, -3, 4, -1, 2, 1, -5, 4};
+    const auto quantum_sequence = to_quantum(sequence);
     std::cout << "maximum_subarray([-2,1,-3,4,-1,2,1,-5,4]) -> "
-              << maximum_subarray(sequence) << "\n";
+              << maximum_subarray(quantum_sequence) << "\n";
 
     const std::vector<int> jumps_success{2, 3, 1, 1, 4};
     const std::vector<int> jumps_failure{3, 2, 1, 0, 4};


### PR DESCRIPTION
## Summary
- add a helper in the greedy namespace to collapse quantum integers to classical scalars
- update the Kadane iteration to collapse quantum inputs before performing arithmetic and fix the loop index type
- refresh the greedy example to build quantum inputs before calling `maximum_subarray`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f00d8e587c832f8c354d5dc8fd1c5c