### PR TITLE
Adapt greedy greedy example to quantum inputs

### DIFF
--- a/examples/data-structures-and-algorithms/greedy/greedy.hpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.hpp
@@ -16,18 +16,17 @@ namespace qpp::examples::greedy {
 namespace detail {
 
 inline std::array<int, 4> sample_axes(const qint& value) {
-    return {value.sample_axis(0U), value.sample_axis(1U), value.sample_axis(2U),
-            value.sample_axis(3U)};
+    return {value.x_step()(), value.y_step()(), value.z_step()(), value.t_step()()};
 }
 
 inline int collapse_axes_to_scalar(const std::array<int, 4>& axes) {
-    int scalar = 0;
-    int scale = 1;
-    for (int measurement : axes) {
-        scalar += measurement * scale;
-        scale *= 3;
+    const int sign = axes[0] >= 0 ? 1 : -1;
+    int magnitude = 0;
+    for (std::size_t bit = 1; bit < axes.size(); ++bit) {
+        if (axes[bit] > 0)
+            magnitude |= 1 << (bit - 1);
     }
-    return scalar;
+    return sign * magnitude;
 }
 
 inline int collapse_to_scalar(const qint& value) {
@@ -54,12 +53,17 @@ inline int maximum_subarray(const std::qvector<qint>& nums) {
 
 
 /// Determine whether it is possible to reach the last index.
-inline bool can_jump(const std::vector<int>& nums) {
+inline bool can_jump(const std::qvector<qint>& nums) {
+    const auto collapse_step = [](const qint& value) {
+        return detail::collapse_to_scalar(value);
+    };
+
     std::size_t furthest = 0;
     for (std::size_t i = 0; i < nums.size(); ++i) {
         if (i > furthest)
             return false;
-        const std::size_t step = static_cast<std::size_t>(std::max(nums[i], 0));
+        const int collapsed = collapse_step(nums[i]);
+        const std::size_t step = static_cast<std::size_t>(std::max(collapsed, 0));
         furthest = std::max(furthest, i + step);
         if (furthest + 1 >= nums.size())
             return true;
@@ -68,7 +72,7 @@ inline bool can_jump(const std::vector<int>& nums) {
 }
 
 /// Build a register encoding reachable prefixes for the jump game instance.
-inline qpp::qclass reachable_prefix_superposition(const std::vector<int>& nums) {
+inline qpp::qclass reachable_prefix_superposition(const std::qvector<qint>& nums) {
     const std::size_t n = nums.size();
     std::size_t qubits = 0;
     while ((std::size_t{1} << qubits) < std::max<std::size_t>(n, 1))
@@ -88,11 +92,16 @@ inline qpp::qclass reachable_prefix_superposition(const std::vector<int>& nums) 
     if (n == 0)
         return reg;
 
+    const auto collapse_step = [](const qint& value) {
+        return detail::collapse_to_scalar(value);
+    };
+
     std::size_t furthest = 0;
     for (std::size_t i = 0; i < n; ++i) {
         if (i > furthest)
             break;
-        const std::size_t step = static_cast<std::size_t>(std::max(nums[i], 0));
+        const int collapsed = collapse_step(nums[i]);
+        const std::size_t step = static_cast<std::size_t>(std::max(collapsed, 0));
         const std::size_t reach = i + step;
         if (reach > furthest)
             furthest = std::min<std::size_t>(reach, n - 1);

--- a/examples/data-structures-and-algorithms/greedy/greedy.qpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.qpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <complex>
 #include <iomanip>
 #include <iostream>
@@ -30,11 +31,19 @@ void print_state(const qpp::qstruct& state, const std::string& label) {
 int main() {
     using namespace qpp::examples::greedy;
 
-    const auto to_quantum = [](const std::vector<int>& classical_values) {
+    const auto to_quantum = [](const auto& classical_values) {
         std::qvector<::qint> quantum_values;
         quantum_values.reserve(classical_values.size());
-        for (int value : classical_values)
-            quantum_values.emplace_back(::qint{value, value, value, value});
+        for (int value : classical_values) {
+            const int sign = value >= 0 ? 1 : -1;
+            const unsigned magnitude = static_cast<unsigned>(std::abs(value));
+            std::array<int, 4> axes{sign, -1, -1, -1};
+            for (std::size_t bit = 0; bit < 3; ++bit) {
+                const bool bit_set = (magnitude >> bit) & 1U;
+                axes[bit + 1] = bit_set ? 1 : -1;
+            }
+            quantum_values.emplace_back(::qint{axes[0], axes[1], axes[2], axes[3]});
+        }
         return quantum_values;
     };
 
@@ -43,8 +52,8 @@ int main() {
     std::cout << "maximum_subarray([-2,1,-3,4,-1,2,1,-5,4]) -> "
               << maximum_subarray(quantum_sequence) << "\n";
 
-    const std::vector<int> jumps_success{2, 3, 1, 1, 4};
-    const std::vector<int> jumps_failure{3, 2, 1, 0, 4};
+    const auto jumps_success = to_quantum(std::vector<int>{2, 3, 1, 1, 4});
+    const auto jumps_failure = to_quantum(std::vector<int>{3, 2, 1, 0, 4});
     std::cout << std::boolalpha;
     std::cout << "can_jump([2,3,1,1,4]) -> " << can_jump(jumps_success) << "\n";
     std::cout << "can_jump([3,2,1,0,4]) -> " << can_jump(jumps_failure) << "\n";


### PR DESCRIPTION
## Summary
- update the greedy helper functions to accept `std::qvector<qint>` inputs and collapse each register to a classical step length before computing
- encode integer test data into sign/magnitude qubit orientations and build the greedy example datasets as quantum vectors

## Testing
- g++ -std=c++17 -I include -x c++ examples/data-structures-and-algorithms/greedy/greedy.qpp -o /tmp/greedy_example
- /tmp/greedy_example

------
https://chatgpt.com/codex/tasks/task_e_68f010cc17d4832f80767b72abd3cd8b