### PR TITLE
Add quantum heap support to median finder example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 enable_testing()
 
 # Core library containing the quantum worlds implementation
-add_library(worlds_lib qpp/quantum_worlds.cpp qpp/quantum/backend.cpp)
+add_library(worlds_lib qpp/quantum_worlds.cpp qpp/quantum/backend.cpp
+                         qpp/quantum/quantum_heap.cpp)
 target_include_directories(worlds_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
 # Lightweight testing framework used by unit tests

--- a/examples/data-structures-and-algorithms/heap/README.md
+++ b/examples/data-structures-and-algorithms/heap/README.md
@@ -1,0 +1,19 @@
+# Quantum Heap Median Finder
+
+The median finder example now relies on the reusable
+[`qpp::quantum::QuantumHeap`](../../../qpp/quantum/quantum_heap.hpp) implementation.
+Both halves of the streaming median structure share the same backend configuration so
+that comparisons, rebalancing, and element transfers are all routed through the quantum
+sampling pipeline.
+
+To exercise the quantum heap directly, build and run the `median_finder.qpp` sample. In
+addition to the running median demonstration, it now prints the results of a standalone
+max/min heap transfer driven by the quantum backend so you can confirm that the
+probabilistic ordering is wired up correctly.
+
+```sh
+qpp++ examples/data-structures-and-algorithms/heap/median_finder.qpp
+```
+
+The program seeds the backend with a deterministic value and uses 128 sampling shots so
+results are reproducible while still showcasing the quantum-aware APIs.

--- a/examples/data-structures-and-algorithms/heap/median_finder.hpp
+++ b/examples/data-structures-and-algorithms/heap/median_finder.hpp
@@ -1,27 +1,51 @@
 #pragma once
 
 #include <cstddef>
-#include <functional>
 #include <initializer_list>
-#include <queue>
 #include <stdexcept>
 #include <vector>
+
+#include "qpp/quantum/quantum_heap.hpp"
 
 namespace qpp::examples::heap {
 
 /// A streaming median data structure built on top of two heaps.
 class MedianFinder {
   public:
-    MedianFinder() = default;
+    using QuantumHeap = qpp::quantum::QuantumHeap;
+
+    MedianFinder()
+        : MedianFinder(qpp::quantum::BackendKind::CPU, qpp::quantum::BackendConfiguration{}, 0) {}
+
+    MedianFinder(qpp::quantum::BackendKind backend,
+                 qpp::quantum::BackendConfiguration config = {},
+                 std::size_t shots = 0)
+        : lower_half_{QuantumHeap::Order::Max, backend, config, shots},
+          upper_half_{QuantumHeap::Order::Min, backend, config, shots} {}
 
     template <typename InputIt>
-    MedianFinder(InputIt first, InputIt last) {
+    MedianFinder(InputIt first, InputIt last,
+                 qpp::quantum::BackendKind backend = qpp::quantum::BackendKind::CPU,
+                 qpp::quantum::BackendConfiguration config = {},
+                 std::size_t shots = 0)
+        : MedianFinder(backend, config, shots) {
         for (; first != last; ++first)
             addNum(*first);
     }
 
-    MedianFinder(std::initializer_list<int> values)
-        : MedianFinder(values.begin(), values.end()) {}
+    MedianFinder(std::initializer_list<int> values,
+                 qpp::quantum::BackendKind backend = qpp::quantum::BackendKind::CPU,
+                 qpp::quantum::BackendConfiguration config = {},
+                 std::size_t shots = 0)
+        : MedianFinder(values.begin(), values.end(), backend, config, shots) {}
+
+    /// Configure both quantum heaps with a shared backend and sampling policy.
+    void configure(qpp::quantum::BackendKind backend,
+                   qpp::quantum::BackendConfiguration config = {},
+                   std::size_t shots = 0) {
+        lower_half_.configure_backend(backend, config, shots);
+        upper_half_.configure_backend(backend, config, shots);
+    }
 
     /// Add a number from the stream to the data structure.
     void addNum(int num) {
@@ -56,16 +80,14 @@ class MedianFinder {
   private:
     void rebalance() {
         if (lower_half_.size() > upper_half_.size() + 1) {
-            upper_half_.push(lower_half_.top());
-            lower_half_.pop();
+            lower_half_.transfer_top_to(upper_half_);
         } else if (upper_half_.size() > lower_half_.size() + 1) {
-            lower_half_.push(upper_half_.top());
-            upper_half_.pop();
+            upper_half_.transfer_top_to(lower_half_);
         }
     }
 
-    std::priority_queue<int> lower_half_;
-    std::priority_queue<int, std::vector<int>, std::greater<>> upper_half_;
+    QuantumHeap lower_half_;
+    QuantumHeap upper_half_;
 };
 
 /// Compute the running median for each prefix of the input sequence.

--- a/examples/data-structures-and-algorithms/heap/median_finder.qpp
+++ b/examples/data-structures-and-algorithms/heap/median_finder.qpp
@@ -3,12 +3,40 @@
 #include <iostream>
 #include <vector>
 
+#include "qpp/quantum/backend.hpp"
+#include "qpp/quantum/quantum_heap.hpp"
+
 #include "median_finder.hpp"
+
+namespace {
+void demonstrate_quantum_heap() {
+    qpp::quantum::BackendConfiguration config;
+    config.seed = 7;
+
+    qpp::quantum::QuantumHeap max_heap(qpp::quantum::QuantumHeap::Order::Max,
+                                       qpp::quantum::BackendKind::CPU, config, 16);
+    for (int value : {4, 1, 7, 3})
+        max_heap.push(value);
+
+    std::cout << "Quantum max-heap top -> " << max_heap.top() << "\n";
+
+    qpp::quantum::QuantumHeap min_heap(qpp::quantum::QuantumHeap::Order::Min,
+                                       qpp::quantum::BackendKind::CPU, config, 16);
+    while (max_heap.transfer_top_to(min_heap))
+        ;
+
+    std::cout << "Quantum min-heap top after transfer -> " << min_heap.top() << "\n";
+}
+} // namespace
 
 int main() {
     using namespace qpp::examples::heap;
 
-    MedianFinder finder;
+    qpp::quantum::BackendConfiguration config;
+    config.seed = 42;
+    const std::size_t shots = 128;
+
+    MedianFinder finder(qpp::quantum::BackendKind::CPU, config, shots);
     const std::vector<int> stream{1, 2, 3, 4, 5, 6};
 
     std::cout << std::fixed << std::setprecision(1);
@@ -18,7 +46,7 @@ int main() {
                   << ", median -> " << finder.findMedian() << "\n";
     }
 
-    const MedianFinder seeded{10, 20, 30};
+    MedianFinder seeded({10, 20, 30}, qpp::quantum::BackendKind::CPU, config, shots);
     std::cout << "Seeded MedianFinder median -> " << seeded.findMedian() << "\n";
 
     const std::vector<int> unsorted{5, 15, 1, 3};
@@ -27,6 +55,8 @@ int main() {
     std::cout << "Running medians for {5, 15, 1, 3}:\n";
     for (std::size_t index = 0; index < medians.size(); ++index)
         std::cout << "  prefix " << (index + 1) << " -> " << medians[index] << "\n";
+
+    demonstrate_quantum_heap();
 
     return 0;
 }

--- a/qpp/quantum/quantum_heap.cpp
+++ b/qpp/quantum/quantum_heap.cpp
@@ -1,0 +1,151 @@
+#include "qpp/quantum/quantum_heap.hpp"
+
+#include <algorithm>
+
+namespace qpp::quantum {
+
+namespace {
+[[nodiscard]] std::vector<double> build_weights(QuantumHeap::Order order, int lhs, int rhs) {
+    if (order == QuantumHeap::Order::Max)
+        return {static_cast<double>(lhs), static_cast<double>(rhs)};
+    return {static_cast<double>(-lhs), static_cast<double>(-rhs)};
+}
+} // namespace
+
+QuantumHeap::QuantumHeap(Order order, BackendKind backend, BackendConfiguration config,
+                         std::size_t shots)
+    : order_{order},
+      backend_kind_{backend},
+      backend_config_{std::move(config)},
+      shots_{shots},
+      data_{},
+      backend_{} {
+    ensure_backend();
+}
+
+QuantumHeap::QuantumHeap(const QuantumHeap& other)
+    : order_{other.order_},
+      backend_kind_{other.backend_kind_},
+      backend_config_{other.backend_config_},
+      shots_{other.shots_},
+      data_{other.data_},
+      backend_{} {
+    ensure_backend();
+}
+
+QuantumHeap& QuantumHeap::operator=(const QuantumHeap& other) {
+    if (this == &other)
+        return *this;
+    order_ = other.order_;
+    backend_kind_ = other.backend_kind_;
+    backend_config_ = other.backend_config_;
+    shots_ = other.shots_;
+    data_ = other.data_;
+    backend_.reset();
+    ensure_backend();
+    return *this;
+}
+
+QuantumHeap::~QuantumHeap() = default;
+
+const QuantumHeap::value_type& QuantumHeap::top() const {
+    if (data_.empty())
+        throw std::logic_error("QuantumHeap::top: heap is empty");
+    return data_.front();
+}
+
+void QuantumHeap::push(value_type value) {
+    data_.push_back(value);
+    if (data_.size() == 1)
+        return;
+    sift_up(data_.size() - 1);
+}
+
+QuantumHeap::value_type QuantumHeap::pop() {
+    if (data_.empty())
+        throw std::logic_error("QuantumHeap::pop: heap is empty");
+
+    value_type result = data_.front();
+    data_.front() = data_.back();
+    data_.pop_back();
+    if (!data_.empty())
+        sift_down(0);
+    return result;
+}
+
+void QuantumHeap::clear() noexcept {
+    data_.clear();
+}
+
+bool QuantumHeap::transfer_top_to(QuantumHeap& other) {
+    if (empty())
+        return false;
+    other.push(pop());
+    return true;
+}
+
+void QuantumHeap::configure_backend(BackendKind backend, BackendConfiguration config,
+                                    std::size_t shots) {
+    backend_kind_ = backend;
+    backend_config_ = std::move(config);
+    shots_ = shots;
+    backend_.reset();
+    ensure_backend();
+}
+
+void QuantumHeap::sift_up(std::size_t index) {
+    while (index > 0) {
+        std::size_t parent = (index - 1) / 2;
+        if (!should_promote(parent, index))
+            break;
+        std::swap(data_[parent], data_[index]);
+        index = parent;
+    }
+}
+
+void QuantumHeap::sift_down(std::size_t index) {
+    const std::size_t size = data_.size();
+    while (true) {
+        std::size_t left = index * 2 + 1;
+        std::size_t right = index * 2 + 2;
+        std::size_t candidate = index;
+
+        if (left < size && should_promote(candidate, left))
+            candidate = left;
+        if (right < size && should_promote(candidate, right))
+            candidate = right;
+
+        if (candidate == index)
+            break;
+
+        std::swap(data_[index], data_[candidate]);
+        index = candidate;
+    }
+}
+
+bool QuantumHeap::should_promote(std::size_t parent, std::size_t child) {
+    return prefers_rhs(data_[parent], data_[child]);
+}
+
+bool QuantumHeap::prefers_rhs(value_type lhs, value_type rhs) {
+    ensure_backend();
+
+    auto weights = build_weights(order_, lhs, rhs);
+    auto result = backend_->run_distribution_experiment(weights, shots_);
+    if (result.size() >= 2)
+        return result.front() < result.back();
+
+    if (order_ == Order::Max)
+        return lhs < rhs;
+    return lhs > rhs;
+}
+
+void QuantumHeap::ensure_backend() const {
+    if (backend_)
+        return;
+    BackendConfiguration config_copy = backend_config_;
+    backend_ = make_backend(backend_kind_, std::move(config_copy));
+}
+
+} // namespace qpp::quantum
+

--- a/qpp/quantum/quantum_heap.hpp
+++ b/qpp/quantum/quantum_heap.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "qpp/quantum/backend.hpp"
+#include "qpp/quantum_worlds.hpp"
+
+namespace qpp::quantum {
+
+/// Quantum-aware heap that delegates ordering decisions to a backend.
+class QuantumHeap {
+  public:
+    enum class Order { Max, Min };
+
+    using value_type = int;
+
+    QuantumHeap(Order order = Order::Max,
+                BackendKind backend = BackendKind::CPU,
+                BackendConfiguration config = {},
+                std::size_t shots = 0);
+
+    QuantumHeap(const QuantumHeap& other);
+    QuantumHeap(QuantumHeap&& other) noexcept = default;
+    QuantumHeap& operator=(const QuantumHeap& other);
+    QuantumHeap& operator=(QuantumHeap&& other) noexcept = default;
+
+    ~QuantumHeap();
+
+    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
+    [[nodiscard]] std::size_t size() const noexcept { return data_.size(); }
+    [[nodiscard]] const value_type& top() const;
+
+    void push(value_type value);
+    value_type pop();
+    void clear() noexcept;
+
+    bool transfer_top_to(QuantumHeap& other);
+
+    void configure_backend(BackendKind backend, BackendConfiguration config,
+                           std::size_t shots = 0);
+
+    void set_shots(std::size_t shots) noexcept { shots_ = shots; }
+    [[nodiscard]] std::size_t shots() const noexcept { return shots_; }
+    [[nodiscard]] BackendKind backend_kind() const noexcept { return backend_kind_; }
+
+  private:
+    void sift_up(std::size_t index);
+    void sift_down(std::size_t index);
+    bool should_promote(std::size_t parent, std::size_t child);
+    bool prefers_rhs(value_type lhs, value_type rhs);
+    void ensure_backend() const;
+
+    Order order_;
+    BackendKind backend_kind_;
+    BackendConfiguration backend_config_;
+    std::size_t shots_;
+    std::vector<value_type> data_;
+    mutable std::unique_ptr<QubitBackend> backend_;
+};
+
+} // namespace qpp::quantum
+


### PR DESCRIPTION
## Summary
- add a reusable qpp::quantum::QuantumHeap abstraction that uses the configured backend for ordering and transfers
- switch the median finder helper to the quantum heap implementation and expose backend configuration hooks
- refresh the heap example and documentation to seed the backend and demonstrate direct quantum heap usage

## Testing
- cmake -S . -B build
- cmake --build build --target worlds_lib


------
https://chatgpt.com/codex/tasks/task_e_68f0133b497c832fa544960902b6941b