### PR TITLE
Refactor interval algorithms to operate on quantum intervals

### DIFF
--- a/examples/data-structures-and-algorithms/intervals/intervals.hpp
+++ b/examples/data-structures-and-algorithms/intervals/intervals.hpp
@@ -1,95 +1,156 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <complex>
 #include <cstddef>
 #include <vector>
 
 #include "qpp/pbool.h"
+#include "qpp/qint"
 #include "qpp/qstruct.hpp"
+#include "qpp/qvector"
 
 namespace qpp::examples::intervals {
 
-using interval = std::array<int, 2>;
+struct quantum_interval {
+    qpp::qint start{};
+    qpp::qint end{};
+};
+
+namespace detail {
+
+struct classical_interval {
+    int start{};
+    int end{};
+};
+
+inline int collapse_endpoint(const qpp::qint& endpoint) {
+    const auto stats = endpoint.measure_axis(0U);
+    if (stats.collapsed_value)
+        return *stats.collapsed_value;
+    return endpoint.x_step()();
+}
+
+inline classical_interval collapse_interval(const quantum_interval& interval) {
+    return classical_interval{collapse_endpoint(interval.start),
+                              collapse_endpoint(interval.end)};
+}
+
+inline std::vector<classical_interval>
+collapse_intervals(const std::qvector<quantum_interval>& intervals) {
+    std::vector<classical_interval> collapsed;
+    collapsed.reserve(intervals.size());
+    for (const auto& interval : intervals)
+        collapsed.push_back(collapse_interval(interval));
+    return collapsed;
+}
+
+inline qpp::qint make_endpoint(int value) {
+    return qpp::qint{value, value, value, value};
+}
+
+inline quantum_interval expand_interval(const classical_interval& interval) {
+    return quantum_interval{make_endpoint(interval.start),
+                            make_endpoint(interval.end)};
+}
+
+inline std::qvector<quantum_interval>
+expand_intervals(const std::vector<classical_interval>& intervals) {
+    std::qvector<quantum_interval> expanded;
+    expanded.reserve(intervals.size());
+    for (const auto& interval : intervals)
+        expanded.push_back(expand_interval(interval));
+    return expanded;
+}
+
+} // namespace detail
 
 /// Insert a new interval into a sorted list of disjoint intervals.
-inline std::vector<interval> insert_interval(std::vector<interval> intervals,
-                                             interval new_interval) {
-    std::vector<interval> result;
-    result.reserve(intervals.size() + 1);
+inline std::qvector<quantum_interval>
+insert_interval(const std::qvector<quantum_interval>& intervals,
+                const quantum_interval& new_interval) {
+    const auto collapsed = detail::collapse_intervals(intervals);
+    detail::classical_interval merged_new = detail::collapse_interval(new_interval);
+
+    std::vector<detail::classical_interval> result;
+    result.reserve(collapsed.size() + 1);
 
     std::size_t index = 0;
-    while (index < intervals.size() &&
-           intervals[index][1] < new_interval[0]) {
-        result.push_back(intervals[index]);
+    while (index < collapsed.size() &&
+           collapsed[index].end < merged_new.start) {
+        result.push_back(collapsed[index]);
         ++index;
     }
 
-    while (index < intervals.size() &&
-           intervals[index][0] <= new_interval[1]) {
-        new_interval[0] = std::min(new_interval[0], intervals[index][0]);
-        new_interval[1] = std::max(new_interval[1], intervals[index][1]);
+    while (index < collapsed.size() &&
+           collapsed[index].start <= merged_new.end) {
+        merged_new.start = std::min(merged_new.start, collapsed[index].start);
+        merged_new.end = std::max(merged_new.end, collapsed[index].end);
         ++index;
     }
 
-    result.push_back(new_interval);
+    result.push_back(merged_new);
 
-    while (index < intervals.size()) {
-        result.push_back(intervals[index]);
+    while (index < collapsed.size()) {
+        result.push_back(collapsed[index]);
         ++index;
     }
 
-    return result;
+    return detail::expand_intervals(result);
 }
 
 /// Merge all overlapping intervals.
-inline std::vector<interval> merge_intervals(std::vector<interval> intervals) {
-    if (intervals.empty())
+inline std::qvector<quantum_interval>
+merge_intervals(const std::qvector<quantum_interval>& intervals) {
+    auto collapsed = detail::collapse_intervals(intervals);
+    if (collapsed.empty())
         return {};
 
-    std::sort(intervals.begin(), intervals.end(),
-              [](const interval& lhs, const interval& rhs) {
-                  if (lhs[0] != rhs[0])
-                      return lhs[0] < rhs[0];
-                  return lhs[1] < rhs[1];
+    std::sort(collapsed.begin(), collapsed.end(),
+              [](const detail::classical_interval& lhs,
+                 const detail::classical_interval& rhs) {
+                  if (lhs.start != rhs.start)
+                      return lhs.start < rhs.start;
+                  return lhs.end < rhs.end;
               });
 
-    std::vector<interval> merged;
-    merged.reserve(intervals.size());
-    merged.push_back(intervals.front());
+    std::vector<detail::classical_interval> merged;
+    merged.reserve(collapsed.size());
+    merged.push_back(collapsed.front());
 
-    for (std::size_t i = 1; i < intervals.size(); ++i) {
-        interval& back = merged.back();
-        if (intervals[i][0] <= back[1]) {
-            back[1] = std::max(back[1], intervals[i][1]);
+    for (std::size_t i = 1; i < collapsed.size(); ++i) {
+        detail::classical_interval& back = merged.back();
+        if (collapsed[i].start <= back.end) {
+            back.end = std::max(back.end, collapsed[i].end);
         } else {
-            merged.push_back(intervals[i]);
+            merged.push_back(collapsed[i]);
         }
     }
 
-    return merged;
+    return detail::expand_intervals(merged);
 }
 
 /// Minimum number of intervals to remove so that the remainder do not overlap.
-inline int erase_overlap_intervals(const std::vector<interval>& intervals) {
+inline int
+erase_overlap_intervals(const std::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return 0;
 
-    std::vector<interval> sorted = intervals;
+    auto sorted = detail::collapse_intervals(intervals);
     std::sort(sorted.begin(), sorted.end(),
-              [](const interval& lhs, const interval& rhs) {
-                  if (lhs[1] != rhs[1])
-                      return lhs[1] < rhs[1];
-                  return lhs[0] < rhs[0];
+              [](const detail::classical_interval& lhs,
+                 const detail::classical_interval& rhs) {
+                  if (lhs.end != rhs.end)
+                      return lhs.end < rhs.end;
+                  return lhs.start < rhs.start;
               });
 
     int removals = 0;
-    interval current = sorted.front();
+    detail::classical_interval current = sorted.front();
 
     for (std::size_t i = 1; i < sorted.size(); ++i) {
-        if (sorted[i][0] < current[1]) {
+        if (sorted[i].start < current.end) {
             ++removals;
         } else {
             current = sorted[i];
@@ -100,19 +161,22 @@ inline int erase_overlap_intervals(const std::vector<interval>& intervals) {
 }
 
 /// Determine whether all meetings can be attended without overlaps.
-inline bool can_attend_all_meetings(std::vector<interval> intervals) {
+inline bool
+can_attend_all_meetings(const std::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return true;
 
-    std::sort(intervals.begin(), intervals.end(),
-              [](const interval& lhs, const interval& rhs) {
-                  if (lhs[0] != rhs[0])
-                      return lhs[0] < rhs[0];
-                  return lhs[1] < rhs[1];
+    auto collapsed = detail::collapse_intervals(intervals);
+    std::sort(collapsed.begin(), collapsed.end(),
+              [](const detail::classical_interval& lhs,
+                 const detail::classical_interval& rhs) {
+                  if (lhs.start != rhs.start)
+                      return lhs.start < rhs.start;
+                  return lhs.end < rhs.end;
               });
 
-    for (std::size_t i = 1; i < intervals.size(); ++i) {
-        if (intervals[i][0] < intervals[i - 1][1])
+    for (std::size_t i = 1; i < collapsed.size(); ++i) {
+        if (collapsed[i].start < collapsed[i - 1].end)
             return false;
     }
 
@@ -120,7 +184,7 @@ inline bool can_attend_all_meetings(std::vector<interval> intervals) {
 }
 
 /// Minimum number of meeting rooms required to host all intervals.
-inline int min_meeting_rooms(const std::vector<interval>& intervals) {
+inline int min_meeting_rooms(const std::qvector<quantum_interval>& intervals) {
     if (intervals.empty())
         return 0;
 
@@ -129,9 +193,10 @@ inline int min_meeting_rooms(const std::vector<interval>& intervals) {
     starts.reserve(intervals.size());
     ends.reserve(intervals.size());
 
-    for (const auto& item : intervals) {
-        starts.push_back(item[0]);
-        ends.push_back(item[1]);
+    const auto collapsed = detail::collapse_intervals(intervals);
+    for (const auto& item : collapsed) {
+        starts.push_back(item.start);
+        ends.push_back(item.end);
     }
 
     std::sort(starts.begin(), starts.end());
@@ -157,18 +222,19 @@ inline int min_meeting_rooms(const std::vector<interval>& intervals) {
 }
 
 /// Probability bias describing how likely a random pair of intervals overlaps.
-inline qpp::pbool conflict_bias(const std::vector<interval>& intervals) {
+inline qpp::pbool conflict_bias(const std::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return qpp::pbool{0.0};
 
     std::size_t overlaps = 0;
     const std::size_t total_pairs = intervals.size() * (intervals.size() - 1) / 2;
 
-    for (std::size_t i = 0; i < intervals.size(); ++i) {
-        for (std::size_t j = i + 1; j < intervals.size(); ++j) {
+    const auto collapsed = detail::collapse_intervals(intervals);
+    for (std::size_t i = 0; i < collapsed.size(); ++i) {
+        for (std::size_t j = i + 1; j < collapsed.size(); ++j) {
             const bool overlap =
-                !(intervals[i][1] <= intervals[j][0] ||
-                  intervals[j][1] <= intervals[i][0]);
+                !(collapsed[i].end <= collapsed[j].start ||
+                  collapsed[j].end <= collapsed[i].start);
             if (overlap)
                 ++overlaps;
         }

--- a/examples/data-structures-and-algorithms/intervals/intervals.qpp
+++ b/examples/data-structures-and-algorithms/intervals/intervals.qpp
@@ -1,6 +1,7 @@
 #include <iomanip>
 #include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "intervals.hpp"
@@ -25,13 +26,16 @@ void print_state(const qpp::qstruct& state, const std::string& label) {
     }
 }
 
-void print_intervals(const std::vector<qpp::examples::intervals::interval>& intervals,
-                     const std::string& label) {
+void print_intervals(
+    const std::qvector<qpp::examples::intervals::quantum_interval>& intervals,
+    const std::string& label) {
+    const auto collapsed =
+        qpp::examples::intervals::detail::collapse_intervals(intervals);
     std::cout << label << " [";
-    for (std::size_t i = 0; i < intervals.size(); ++i) {
+    for (std::size_t i = 0; i < collapsed.size(); ++i) {
         if (i)
             std::cout << ", ";
-        std::cout << '[' << intervals[i][0] << ',' << intervals[i][1] << ']';
+        std::cout << '[' << collapsed[i].start << ',' << collapsed[i].end << ']';
     }
     std::cout << "]\n";
 }
@@ -40,35 +44,79 @@ void print_intervals(const std::vector<qpp::examples::intervals::interval>& inte
 int main() {
     using namespace qpp::examples::intervals;
 
-    const std::vector<interval> initial{{1, 3}, {6, 9}};
-    const interval new_interval{2, 5};
+    const auto to_quantum = [](const std::vector<std::pair<int, int>>& classical) {
+        std::qvector<quantum_interval> quantum;
+        quantum.reserve(classical.size());
+        for (const auto& bounds : classical) {
+            const detail::classical_interval collapsed{bounds.first, bounds.second};
+            quantum.push_back(detail::expand_interval(collapsed));
+        }
+        return quantum;
+    };
+
+    const std::vector<std::pair<int, int>> classical_initial{{1, 3}, {6, 9}};
+    const std::vector<std::pair<int, int>> classical_new{{2, 5}};
+    const auto initial = to_quantum(classical_initial);
+    const auto new_interval = to_quantum(classical_new).front();
     const auto inserted = insert_interval(initial, new_interval);
     print_intervals(initial, "insert_interval input:");
-    print_intervals(std::vector<interval>{new_interval}, "new interval:");
+    print_intervals(std::qvector<quantum_interval>{new_interval}, "new interval:");
     print_intervals(inserted, "insert_interval output:");
 
-    const std::vector<interval> to_merge{{1, 4}, {0, 2}, {3, 5}, {10, 12}};
+    const std::vector<std::pair<int, int>> classical_to_merge{{1, 4},
+                                                              {0, 2},
+                                                              {3, 5},
+                                                              {10, 12}};
+    const auto to_merge = to_quantum(classical_to_merge);
     const auto merged = merge_intervals(to_merge);
     print_intervals(to_merge, "merge_intervals input:");
     print_intervals(merged, "merge_intervals output:");
 
-    const std::vector<interval> overlaps{{1, 2}, {2, 3}, {3, 4}, {1, 3}};
+    const std::vector<std::pair<int, int>> classical_overlaps{{1, 2},
+                                                              {2, 3},
+                                                              {3, 4},
+                                                              {1, 3}};
+    const auto overlaps = to_quantum(classical_overlaps);
     std::cout << "erase_overlap_intervals -> " << erase_overlap_intervals(overlaps)
               << '\n';
 
-    const std::vector<interval> meetings{{0, 30}, {5, 10}, {15, 20}};
+    const std::vector<std::pair<int, int>> classical_meetings{{0, 30}, {5, 10},
+                                                              {15, 20}};
+    const auto meetings = to_quantum(classical_meetings);
     std::cout << std::boolalpha;
     std::cout << "can_attend_all_meetings({[0,30],[5,10],[15,20]}) -> "
               << can_attend_all_meetings(meetings) << '\n';
 
-    const std::vector<interval> rooms_example{{0, 30}, {5, 10}, {15, 20}, {25, 40}};
+    const std::vector<std::pair<int, int>> classical_rooms{{0, 30},
+                                                           {5, 10},
+                                                           {15, 20},
+                                                           {25, 40}};
+    const auto rooms_example = to_quantum(classical_rooms);
     std::cout << std::noboolalpha;
     std::cout << "min_meeting_rooms({[0,30],[5,10],[15,20],[25,40]}) -> "
               << min_meeting_rooms(rooms_example) << '\n';
 
     const auto bias = conflict_bias(to_merge);
+    const auto collapsed_for_bias = detail::collapse_intervals(to_merge);
+    std::size_t classical_overlaps_count = 0;
+    for (std::size_t i = 0; i < collapsed_for_bias.size(); ++i) {
+        for (std::size_t j = i + 1; j < collapsed_for_bias.size(); ++j) {
+            const bool overlap =
+                !(collapsed_for_bias[i].end <= collapsed_for_bias[j].start ||
+                  collapsed_for_bias[j].end <= collapsed_for_bias[i].start);
+            if (overlap)
+                ++classical_overlaps_count;
+        }
+    }
+    const std::size_t classical_pairs = collapsed_for_bias.size() *
+                                        (collapsed_for_bias.size() - 1) / 2;
+    const double manual_bias = classical_pairs
+                                   ? static_cast<double>(classical_overlaps_count) /
+                                         static_cast<double>(classical_pairs)
+                                   : 0.0;
     std::cout << std::setprecision(4)
-              << "conflict_bias probability -> " << bias.probability() << '\n';
+              << "conflict_bias probability -> " << bias.probability()
+              << " (manual verification=" << manual_bias << ")\n";
 
     const auto interval_register = interval_index_superposition(to_merge.size());
     print_state(interval_register.data(), "Interval index superposition");


### PR DESCRIPTION
## Summary
- introduce a quantum_interval wrapper that stores qpp::qint endpoints and helper utilities for collapsing/expanding them
- update the interval algorithms to consume std::qvector<quantum_interval>, measuring endpoints before classical comparisons
- refresh the sample driver to build quantum intervals and verify the conflict bias against a manual calculation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f01617751c832f8849ca96519b83a3