### PR TITLE
Adopt quantum payloads in linked list examples

### DIFF
--- a/examples/data-structures-and-algorithms/linked-list/README.md
+++ b/examples/data-structures-and-algorithms/linked-list/README.md
@@ -1,0 +1,20 @@
+# Quantum Linked List Toolkit
+
+This example upgrades the classical linked list exercises to operate on the
+project's quantum data structures.  Each node stores a [`qint`](../../../include/qpp/qint)
+payload and traversal utilities return `std::qvector` containers so that
+algorithms can remain quantum-aware while still collapsing values for
+presentation.
+
+The executable example `linked_list_problems.qpp` demonstrates how the helper
+functions expose both quantum and classical views of the structure:
+
+- `to_vector` returns the quantum payloads after ensuring they are measured and
+  entanglement-safe.
+- `to_classical_vector` provides deterministic classical integers for logging.
+- Cycle-aware traversal uses `std::entangled_set` to prevent infinite loops
+  when sampling lists with shared structure.
+
+Running the example prints both the high-level description as well as the
+collapsed measurement results, confirming that the algorithms continue to
+produce the expected orderings using the quantum node representation.

--- a/examples/data-structures-and-algorithms/linked-list/linked_list_problems.hpp
+++ b/examples/data-structures-and-algorithms/linked-list/linked_list_problems.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <initializer_list>
 #include <memory>
 #include <queue>
 #include <sstream>
@@ -7,43 +8,93 @@
 #include <utility>
 #include <vector>
 
+#include "qpp/entangled_set"
+#include "qpp/qint"
+#include "qpp/qvector"
+
 namespace qpp::examples::linked_list {
 
 struct ListNode {
-    int value{};
+    qint value{};
     std::shared_ptr<ListNode> next{};
 };
 
 using NodePtr = std::shared_ptr<ListNode>;
 
-inline NodePtr make_node(int value, NodePtr next = nullptr) {
-    return std::make_shared<ListNode>(ListNode{value, std::move(next)});
+inline qint make_quantum_value(int classical) {
+    return qint{classical, classical, classical, classical};
 }
 
-inline NodePtr make_list(const std::vector<int>& values) {
+inline int collapse_value(const qint& value) {
+    const auto stats = value.measure_axis(0U);
+    if (stats.collapsed_value)
+        return *stats.collapsed_value;
+    return value.x_step()();
+}
+
+inline qint collapse_register(const qint& value) {
+    const auto register_stats = value.measure_register();
+    const auto fetch = [&](std::size_t axis, const qint::MeasurementHandle& handle) {
+        if (register_stats[axis].collapsed_value)
+            return *register_stats[axis].collapsed_value;
+        return handle();
+    };
+
+    const int x = fetch(0U, value.x_step());
+    const int y = fetch(1U, value.y_step());
+    const int z = fetch(2U, value.z_step());
+    const int t = fetch(3U, value.t_step());
+
+    return qint{x, y, z, t};
+}
+
+inline NodePtr make_node(qint value, NodePtr next = nullptr) {
+    return std::make_shared<ListNode>(ListNode{std::move(value), std::move(next)});
+}
+
+inline NodePtr make_node(int value, NodePtr next = nullptr) {
+    return make_node(make_quantum_value(value), std::move(next));
+}
+
+inline NodePtr make_list(std::qvector<qint> values) {
     if (values.empty())
         return nullptr;
 
-    NodePtr head = make_node(values.front());
+    NodePtr head = make_node(std::move(values.front()));
     auto current = head;
 
     for (std::size_t index = 1; index < values.size(); ++index) {
-        current->next = make_node(values[index]);
+        current->next = make_node(std::move(values[index]));
         current = current->next;
     }
 
     return head;
 }
 
-inline std::vector<int> to_vector(const NodePtr& head, std::size_t max_nodes = 64,
-                                  bool* truncated = nullptr) {
-    std::vector<int> values;
+inline NodePtr make_list(const std::vector<int>& values) {
+    std::qvector<qint> quantum_values;
+    quantum_values.reserve(values.size());
+    for (int value : values)
+        quantum_values.emplace_back(make_quantum_value(value));
+    return make_list(std::move(quantum_values));
+}
+
+inline NodePtr make_list(std::initializer_list<int> values) {
+    return make_list(std::vector<int>(values));
+}
+
+inline std::qvector<qint> to_vector(const NodePtr& head,
+                                    std::size_t max_nodes = 64,
+                                    bool* truncated = nullptr) {
+    std::qvector<qint> values;
     values.reserve(max_nodes);
 
+    std::entangled_set<const ListNode*> visited_nodes;
     auto current = head;
     std::size_t visited = 0;
-    while (current && visited < max_nodes) {
-        values.push_back(current->value);
+
+    while (current && visited < max_nodes && visited_nodes.insert(current.get()).second) {
+        values.emplace_back(collapse_register(current->value));
         current = current->next;
         ++visited;
     }
@@ -54,10 +105,21 @@ inline std::vector<int> to_vector(const NodePtr& head, std::size_t max_nodes = 6
     return values;
 }
 
+inline std::vector<int> to_classical_vector(const NodePtr& head,
+                                            std::size_t max_nodes = 64,
+                                            bool* truncated = nullptr) {
+    const auto quantum_values = to_vector(head, max_nodes, truncated);
+    std::vector<int> classical;
+    classical.reserve(quantum_values.size());
+    for (const auto& value : quantum_values)
+        classical.push_back(collapse_value(value));
+    return classical;
+}
+
 inline std::string describe_list(const NodePtr& head,
                                  std::size_t max_nodes = 16) {
     bool truncated = false;
-    const auto values = to_vector(head, max_nodes, &truncated);
+    const auto values = to_classical_vector(head, max_nodes, &truncated);
 
     std::ostringstream stream;
     stream << "[";
@@ -94,11 +156,11 @@ inline NodePtr merge_two_sorted_lists(NodePtr list1, NodePtr list2) {
     if (!list2)
         return list1;
 
-    auto dummy = make_node(0);
+    auto dummy = make_node(make_quantum_value(0));
     auto tail = dummy;
 
     while (list1 && list2) {
-        if (list1->value <= list2->value) {
+        if (collapse_value(list1->value) <= collapse_value(list2->value)) {
             tail->next = list1;
             tail = tail->next;
             list1 = list1->next;
@@ -160,7 +222,7 @@ inline NodePtr reorder_list(NodePtr head) {
 }
 
 inline NodePtr remove_nth_from_end(NodePtr head, int n) {
-    auto dummy = make_node(0, head);
+    auto dummy = make_node(make_quantum_value(0), head);
     auto lead = dummy;
 
     for (int step = 0; step < n && lead; ++step)
@@ -178,19 +240,19 @@ inline NodePtr remove_nth_from_end(NodePtr head, int n) {
     return dummy->next;
 }
 
-inline NodePtr merge_k_sorted_lists(std::vector<NodePtr> lists) {
+inline NodePtr merge_k_sorted_lists(std::qvector<NodePtr> lists) {
     struct NodePtrCompare {
         bool operator()(const NodePtr& lhs, const NodePtr& rhs) const {
-            return lhs->value > rhs->value;
+            return collapse_value(lhs->value) > collapse_value(rhs->value);
         }
     };
 
-    std::priority_queue<NodePtr, std::vector<NodePtr>, NodePtrCompare> heap;
+    std::priority_queue<NodePtr, std::qvector<NodePtr>, NodePtrCompare> heap;
     for (auto& list : lists)
         if (list)
             heap.push(list);
 
-    auto dummy = make_node(0);
+    auto dummy = make_node(make_quantum_value(0));
     auto tail = dummy;
 
     while (!heap.empty()) {

--- a/examples/data-structures-and-algorithms/linked-list/linked_list_problems.qpp
+++ b/examples/data-structures-and-algorithms/linked-list/linked_list_problems.qpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <vector>
 
+#include "qpp/qvector"
+
 #include "linked_list_problems.hpp"
 
 namespace {
@@ -10,9 +12,12 @@ using qpp::examples::linked_list::has_cycle;
 using qpp::examples::linked_list::make_list;
 using qpp::examples::linked_list::merge_k_sorted_lists;
 using qpp::examples::linked_list::merge_two_sorted_lists;
+using qpp::examples::linked_list::NodePtr;
 using qpp::examples::linked_list::remove_nth_from_end;
 using qpp::examples::linked_list::reorder_list;
 using qpp::examples::linked_list::reverse_list;
+using qpp::examples::linked_list::to_classical_vector;
+using qpp::examples::linked_list::to_vector;
 
 } // namespace
 
@@ -21,13 +26,31 @@ int main() {
     std::cout << "Reverse Linked List\n  before: "
               << describe_list(reverse_example) << '\n';
     reverse_example = reverse_list(reverse_example);
-    std::cout << "  after:  " << describe_list(reverse_example) << "\n\n";
+    std::cout << "  after:  " << describe_list(reverse_example) << '\n';
+    const auto reverse_quantum = to_vector(reverse_example);
+    const auto reverse_classical = to_classical_vector(reverse_example);
+    std::cout << "  qvector size: " << reverse_quantum.size() << '\n';
+    std::cout << "  measured values: ";
+    for (std::size_t i = 0; i < reverse_classical.size(); ++i) {
+        if (i > 0)
+            std::cout << ", ";
+        std::cout << reverse_classical[i];
+    }
+    std::cout << "\n\n";
 
     auto list_one = make_list({1, 3, 5});
     auto list_two = make_list({2, 4, 6});
     const auto merged_two = merge_two_sorted_lists(list_one, list_two);
     std::cout << "Merge Two Sorted Lists\n  result: "
-              << describe_list(merged_two) << "\n\n";
+              << describe_list(merged_two) << '\n';
+    const auto merged_two_classical = to_classical_vector(merged_two);
+    std::cout << "  measured merge: ";
+    for (std::size_t i = 0; i < merged_two_classical.size(); ++i) {
+        if (i > 0)
+            std::cout << ", ";
+        std::cout << merged_two_classical[i];
+    }
+    std::cout << "\n\n";
 
     auto cycle_example = make_list({1, 2, 3, 4});
     auto cycle_tail = cycle_example;
@@ -49,11 +72,19 @@ int main() {
     std::cout << "Remove Nth Node From End of List\n  result: "
               << describe_list(removal_example) << "\n\n";
 
-    std::vector merged_inputs{make_list({1, 4, 7}), make_list({2, 5, 8}),
-                              make_list({3, 6, 9})};
+    std::qvector<NodePtr> merged_inputs{
+        make_list({1, 4, 7}), make_list({2, 5, 8}), make_list({3, 6, 9})};
     const auto merged_k = merge_k_sorted_lists(merged_inputs);
     std::cout << "Merge K Sorted Lists\n  result: " << describe_list(merged_k)
-              << "\n";
+              << '\n';
+    const auto merged_k_classical = to_classical_vector(merged_k);
+    std::cout << "  measured merge: ";
+    for (std::size_t i = 0; i < merged_k_classical.size(); ++i) {
+        if (i > 0)
+            std::cout << ", ";
+        std::cout << merged_k_classical[i];
+    }
+    std::cout << "\n";
 
     return 0;
 }


### PR DESCRIPTION
## Summary
- replace the linked list node payload with qint values and add helpers to collapse quantum states for classical inspection
- update linked list algorithms and the runnable example to use qvector inputs and measure outputs
- document the quantum-linked-list workflow for the example

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f0180d9444832fb50bea1afc1525b3