### PR TITLE
Use qvector containers in math and geometry example

### DIFF
--- a/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.hpp
+++ b/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.hpp
@@ -2,7 +2,8 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <vector>
+
+#include "qpp/qvector"
 
 namespace qpp::examples::math_and_geometry {
 
@@ -12,7 +13,7 @@ namespace qpp::examples::math_and_geometry {
 /// outer ring is swapped into its rotated position using temporary storage
 /// for the four involved values. The process is then repeated for the next
 /// inner ring until the center of the matrix is reached.
-inline void rotate_image(std::vector<std::vector<int>>& matrix) {
+inline void rotate_image(std::qvector<std::qvector<int>>& matrix) {
     const std::size_t n = matrix.size();
     if (n == 0)
         return;
@@ -44,12 +45,12 @@ inline void rotate_image(std::vector<std::vector<int>>& matrix) {
 /// The traversal maintains shrinking boundaries for the rows and columns
 /// and iteratively walks along the four directions (right, down, left,
 /// up) until the full matrix has been consumed.
-inline std::vector<int>
-spiral_matrix(const std::vector<std::vector<int>>& matrix) {
+inline std::qvector<int>
+spiral_matrix(const std::qvector<std::qvector<int>>& matrix) {
     if (matrix.empty() || matrix.front().empty())
         return {};
 
-    std::vector<int> result;
+    std::qvector<int> result;
     const std::ptrdiff_t row_count =
         static_cast<std::ptrdiff_t>(matrix.size());
     const std::ptrdiff_t col_count =
@@ -96,7 +97,7 @@ spiral_matrix(const std::vector<std::vector<int>>& matrix) {
 /// The implementation uses the first row and column as marker storage to
 /// achieve constant extra space while keeping track of which rows and
 /// columns must be zeroed out.
-inline void set_matrix_zeroes(std::vector<std::vector<int>>& matrix) {
+inline void set_matrix_zeroes(std::qvector<std::qvector<int>>& matrix) {
     if (matrix.empty() || matrix.front().empty())
         return;
 

--- a/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.qpp
+++ b/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.qpp
@@ -1,10 +1,11 @@
 #include <iostream>
-#include <vector>
+
+#include <qpp/qvector>
 
 #include "math_and_geometry.hpp"
 
 namespace {
-void print_matrix(const std::vector<std::vector<int>>& matrix,
+void print_matrix(const std::qvector<std::qvector<int>>& matrix,
                   const std::string& label) {
     std::cout << label << " (" << matrix.size() << "x"
               << (matrix.empty() ? 0 : matrix.front().size()) << ")\n";
@@ -20,7 +21,7 @@ void print_matrix(const std::vector<std::vector<int>>& matrix,
     std::cout << '\n';
 }
 
-void print_vector(const std::vector<int>& values, const std::string& label) {
+void print_vector(const std::qvector<int>& values, const std::string& label) {
     std::cout << label << " -> [";
     for (std::size_t i = 0; i < values.size(); ++i) {
         if (i)
@@ -34,18 +35,22 @@ void print_vector(const std::vector<int>& values, const std::string& label) {
 int main() {
     using namespace qpp::examples::math_and_geometry;
 
-    std::vector<std::vector<int>> rotate_input{{1, 2, 3}, {4, 5, 6}, {7, 8, 9}};
+    std::qvector<std::qvector<int>> rotate_input{{1, 2, 3},
+                                                 {4, 5, 6},
+                                                 {7, 8, 9}};
     print_matrix(rotate_input, "Original rotate_image input");
     rotate_image(rotate_input);
     print_matrix(rotate_input, "After rotate_image");
 
-    const std::vector<std::vector<int>> spiral_input{{1, 2, 3, 4},
-                                                     {5, 6, 7, 8},
-                                                     {9, 10, 11, 12}};
+    const std::qvector<std::qvector<int>> spiral_input{{1, 2, 3, 4},
+                                                       {5, 6, 7, 8},
+                                                       {9, 10, 11, 12}};
     const auto spiral = spiral_matrix(spiral_input);
     print_vector(spiral, "spiral_matrix traversal");
 
-    std::vector<std::vector<int>> zero_input{{0, 1, 2}, {3, 4, 5}, {6, 0, 7}};
+    std::qvector<std::qvector<int>> zero_input{{0, 1, 2},
+                                               {3, 4, 5},
+                                               {6, 0, 7}};
     print_matrix(zero_input, "Original set_matrix_zeroes input");
     set_matrix_zeroes(zero_input);
     print_matrix(zero_input, "After set_matrix_zeroes");


### PR DESCRIPTION
## Summary
- swap the math and geometry algorithms to use std::qvector containers and include the quantum header
- update the example driver to construct and print qvectors so it builds against the quantum container alias

## Testing
- g++ -std=c++20 -x c++ -Iinclude -Iexamples/data-structures-and-algorithms/math-and-geometry examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.qpp -o /tmp/math_and_geometry_example
- /tmp/math_and_geometry_example

------
https://chatgpt.com/codex/tasks/task_e_68f019aa94bc832fa0cf6c2c592984c9