### PR TITLE
Add std::qarray alias and include in sliding window example

### DIFF
--- a/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
+++ b/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
 #include <cmath>
 #include <complex>
 #include <cstddef>
@@ -11,6 +10,7 @@
 #include <vector>
 
 #include "qpp/pbool.h"
+#include "qpp/qarray"
 #include "qpp/qstruct.hpp"
 
 namespace qpp::examples::sliding_window {

--- a/include/qpp/qarray
+++ b/include/qpp/qarray
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <array>
+
+namespace std {
+
+/**
+ * @brief Alias exposing the standard fixed-size array as a quantum array.
+ *
+ * Providing this alias allows quantum-specific code to reference a qarray
+ * while reusing the optimised implementation of `std::array` and its
+ * compile-time size guarantees.
+ */
+template <typename T, std::size_t N>
+using qarray = std::array<T, N>;
+
+} // namespace std
+


### PR DESCRIPTION
## Summary
- add a qpp header that aliases std::array as std::qarray
- include the new header in the sliding window example so its uses compile

## Testing
- cmake -S examples -B build/examples
- cmake --build build/examples


------
https://chatgpt.com/codex/tasks/task_e_68f01aeda62c832fb15c02c1135953d3