### PR TITLE
Add missing quantum container includes

### DIFF
--- a/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
+++ b/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
@@ -11,7 +11,9 @@
 
 #include "qpp/pbool.h"
 #include "qpp/qarray"
+#include "qpp/qint"
 #include "qpp/qstruct.hpp"
+#include "qpp/qvector"
 
 namespace qpp::examples::sliding_window {
 


### PR DESCRIPTION
## Summary
- include qpp/qint and qpp/qvector in the sliding window example header so the quantum aliases are available

## Testing
- `cmake --build .`

------
https://chatgpt.com/codex/tasks/task_e_68f01bc41560832fb327a821907b5083