### PR TITLE
Add string_view overload for stack parentheses validation

### DIFF
--- a/examples/data-structures-and-algorithms/stack/stack_problems.hpp
+++ b/examples/data-structures-and-algorithms/stack/stack_problems.hpp
@@ -75,6 +75,14 @@ template <typename FetchSymbol>
 } // namespace detail
 
 
+/// Determine whether a bracket string contains a valid sequence of symbols.
+inline bool is_valid_parentheses(std::string_view s) {
+    return detail::validate_sequence(s.size(),
+                                     [s](std::size_t index) {
+                                         return s[index];
+                                     });
+}
+
 /// Determine whether a sequence of encoded bracket tokens is valid.
 inline bool is_valid_parentheses(const std::qvector<qint>& sequence) {
     return detail::validate_sequence(sequence.size(),


### PR DESCRIPTION
## Summary
- add a classical `is_valid_parentheses(std::string_view)` helper that delegates to `detail::validate_sequence`
- keep the quantum overload intact while allowing `parentheses_confidence` to reuse the new helper

## Testing
- cmake -S examples -B build/examples
- cmake --build build/examples --target stack_problems *(fails: target not defined in build scripts)*
- g++ -std=c++17 -x c++ -Iinclude -c examples/data-structures-and-algorithms/stack/stack_problems.qpp -o /tmp/stack.o *(fails: missing quantum dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68f01d73d1b0832f88734de426c926bd