### PR TITLE
Add quantum parentheses wrapper for stack example

### DIFF
--- a/examples/data-structures-and-algorithms/stack/stack_problems.hpp
+++ b/examples/data-structures-and-algorithms/stack/stack_problems.hpp
@@ -93,6 +93,11 @@ inline bool is_valid_parentheses(const std::qvector<qint>& sequence) {
                                      });
 }
 
+/// Convenience wrapper that mirrors the quantum-prefixed API used by the sample.
+inline bool quantum_is_valid_parentheses(const std::qvector<qint>& sequence) {
+    return is_valid_parentheses(sequence);
+}
+
 /// Express confidence in the validity of the provided bracket string.
 inline qpp::pbool parentheses_confidence(std::string_view s) {
     return qpp::pbool{is_valid_parentheses(s) ? 1.0 : 0.0};


### PR DESCRIPTION
## Summary
- add an inline `quantum_is_valid_parentheses` helper so the stack sample resolves the symbol at link time
- reuse the corrected encoded validation logic by delegating to `is_valid_parentheses`

## Testing
- g++ -std=c++20 -Iinclude -I. -x c++ examples/data-structures-and-algorithms/stack/stack_problems.qpp -o stack_example *(fails: existing qint to int conversion errors)*

------
https://chatgpt.com/codex/tasks/task_e_68f01e6b37b8832fbfdeb477d9877f35