### PR TITLE
Refactor palindrome helpers for two pointers

### DIFF
--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
@@ -19,9 +19,8 @@
 
 namespace qpp::examples::two_pointers {
 
-/// Determine whether a string is a palindrome using the same rules as the
-/// classical counterpart.
-inline bool quantum_valid_palindrome(std::string_view s) {
+/// Determine whether a string is a palindrome ignoring punctuation and case.
+inline bool valid_palindrome(std::string_view s) {
     std::size_t left = 0;
     std::size_t right = s.size();
 
@@ -49,10 +48,17 @@ inline bool quantum_valid_palindrome(std::string_view s) {
     return true;
 }
 
+/// Determine whether a string is a palindrome using the same rules as the
+/// classical counterpart.
+inline bool quantum_valid_palindrome(std::string_view s) {
+    return valid_palindrome(s);
+}
+
 /// Probability wrapper describing confidence that the provided string is a
 /// palindrome.
 inline qpp::pbool palindrome_bias(std::string_view s) {
-    return qpp::pbool{valid_palindrome(s) ? 1.0 : 0.0};
+    const double probability = valid_palindrome(s) ? 1.0 : 0.0;
+    return qpp::pbool{probability};
 }
 
 

--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
@@ -44,9 +44,12 @@ int main() {
     const std::string palindrome_sample = "A man, a plan, a canal: Panama";
     const std::string non_palindrome_sample = "quantum register";
     std::cout << "valid_palindrome('" << palindrome_sample << "') -> "
-              << valid_palindrome(palindrome_sample) << '\n';
+              << qpp::examples::two_pointers::valid_palindrome(palindrome_sample)
+              << '\n';
     std::cout << "valid_palindrome('" << non_palindrome_sample << "') -> "
-              << valid_palindrome(non_palindrome_sample) << '\n';
+              << qpp::examples::two_pointers::valid_palindrome(
+                     non_palindrome_sample)
+              << '\n';
 
     std::cout << "quantum_valid_palindrome('Able was I ere I saw Elba') -> "
               << quantum_valid_palindrome("Able was I ere I saw Elba") << '\n';


### PR DESCRIPTION
## Summary
- add a reusable `valid_palindrome` helper for the two-pointer examples and share it with the quantum variant
- build `palindrome_bias` on top of the shared helper while preserving probability semantics
- update the example driver to call the fully-qualified helper for compilation clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f02485eee0832fa663f64b1d5cba5e