### PR TITLE
Implement quantum-aware qvector container with metadata and notifications

### DIFF
--- a/docs/data-structures/quantum_containers.md
+++ b/docs/data-structures/quantum_containers.md
@@ -63,15 +63,29 @@ that hashed containers remain stable after the first observation.
 
 ## `qvector`: quantum-friendly dynamic arrays
 
-`std::qvector<T>` is a straightforward alias for `std::vector<T>` that resides in
-the standard namespace. The alias lets educational material refer to "quantum
-vectors" without sacrificing the familiarity or performance characteristics of
-the standard dynamic array. Any API that works with `std::vector`—iterators,
-capacity management, algorithms—works identically with `std::qvector`.
+`qpp::qvector<T>` extends the ergonomics of `std::vector` with a lightweight
+quantum state tracker. Each container owns a classical `std::vector<T>` **and**
+an accompanying `qpp::quantum::qstate` that records amplitudes, cached
+probabilities, and collapse state. The two views stay in lockstep:
 
-When storing `qint` values, `std::qvector<qint>` becomes the natural building
-block for quantum sequences. You can reserve capacity, push states, and iterate
-with range-based `for` loops exactly as you would with classical data.
+- Structural operations (`push_back`, `insert`, `erase`, `resize`) delegate to
+  the classical vector and then rebalance the quantum metadata via helpers from
+  `qpp/quantum/state.hpp`. Amplitudes remain normalised, and collapsed states are
+  preserved when possible so superpositions survive typical container edits.
+- Accessors mirror the STL: iterators, `size()`, `operator[]`, `front()`, and
+  friends all forward to the underlying vector. Algorithms that expect
+  `std::vector` iterators therefore work transparently with `qpp::qvector`.
+- Quantum-specific hooks expose the extra state. Call `probabilities()` or
+  `probability_of(index)` to retrieve normalised measurement distributions, and
+  `measure(index)` to collapse the vector to a concrete branch. Copying a
+  container or measuring an element emits notifications through
+  `qpp::backend::set_notification_sink`, allowing simulators and backends to
+  react to classical observation events.
+
+When storing `qint` values, `qpp::qvector<qint>` becomes the natural building
+block for quantum sequences. You can reserve capacity, push states, iterate with
+range-based `for` loops, and still ask the container how likely each element is
+to appear after a measurement.
 
 ## `entangled_set`: context-aware hash sets
 
@@ -105,7 +119,7 @@ questions in a quantum context. The duplicate-check routine below highlights the
 interplay between all three types:
 
 ```cpp
-std::qvector<qint> states = {/* ... prepare quantum inputs ... */};
+qpp::qvector<qint> states = {/* ... prepare quantum inputs ... */};
 std::entangled_set<qint> visited;
 visited.reserve(states.size());
 for (const auto& state : states) {
@@ -116,7 +130,8 @@ for (const auto& state : states) {
 return false;
 ```
 
-- `qvector` provides contiguous storage for a sequence of `qint` states.
+- `qvector` provides contiguous storage for a sequence of `qint` states and lets
+  you inspect or collapse their shared superposition when necessary.
 - Each `qint` carries multi-axis orientation data while remaining hashable.
 - `entangled_set` tracks which states have been observed using its salted hash
   function.

--- a/examples/data-structures-and-algorithms/advanced-graphs/alien_dictionary.hpp
+++ b/examples/data-structures-and-algorithms/advanced-graphs/alien_dictionary.hpp
@@ -17,8 +17,8 @@ using CharSet = std::entangled_set<char, CharHash, CharEqual>;
 using CharDegreeMap = std::entangled_map<char, std::size_t, CharHash, CharEqual>;
 using Graph = std::entangled_map<char, CharSet, CharHash, CharEqual>;
 using Indegrees = CharDegreeMap;
-using CharStack = std::qvector<char>;
-using CharQueue = std::qvector<char>;
+using CharStack = qpp::qvector<char>;
+using CharQueue = qpp::qvector<char>;
 
 struct GraphAnalysis {
     Graph adjacency;
@@ -27,15 +27,15 @@ struct GraphAnalysis {
 };
 
 struct AlienDictionaryResult {
-    std::qvector<char> order;
+    qpp::qvector<char> order;
     bool valid{true};
     bool has_cycle{false};
     bool has_prefix_conflict{false};
     bool is_unique{false};
-    std::qvector<std::qvector<char>> strongly_connected;
+    qpp::qvector<qpp::qvector<char>> strongly_connected;
 };
 
-inline GraphAnalysis build_dependency_graph(const std::qvector<std::string>& words) {
+inline GraphAnalysis build_dependency_graph(const qpp::qvector<std::string>& words) {
     GraphAnalysis analysis{};
     auto& adjacency = analysis.adjacency;
     auto& indegree = analysis.indegree;
@@ -75,7 +75,7 @@ inline void tarjan_dfs(const Graph& graph, char node, std::size_t& index,
                        CharDegreeMap& indices,
                        CharDegreeMap& lowlinks,
                        CharSet& on_stack, CharStack& stack,
-                       std::qvector<std::qvector<char>>& components) {
+                       qpp::qvector<qpp::qvector<char>>& components) {
     indices[node] = index;
     lowlinks[node] = index;
     ++index;
@@ -83,7 +83,7 @@ inline void tarjan_dfs(const Graph& graph, char node, std::size_t& index,
     on_stack.insert(node);
 
     if (const auto it = graph.find(node); it != graph.end()) {
-        std::qvector<char> neighbors(it->second.begin(), it->second.end());
+        qpp::qvector<char> neighbors(it->second.begin(), it->second.end());
         std::sort(neighbors.begin(), neighbors.end());
         for (const auto neighbor : neighbors) {
             if (!indices.count(neighbor)) {
@@ -96,7 +96,7 @@ inline void tarjan_dfs(const Graph& graph, char node, std::size_t& index,
     }
 
     if (lowlinks[node] == indices[node]) {
-        std::qvector<char> component;
+        qpp::qvector<char> component;
         while (!stack.empty()) {
             const auto top = stack.back();
             stack.pop_back();
@@ -109,15 +109,15 @@ inline void tarjan_dfs(const Graph& graph, char node, std::size_t& index,
     }
 }
 
-inline std::qvector<std::qvector<char>> strongly_connected_components(const Graph& graph) {
+inline qpp::qvector<qpp::qvector<char>> strongly_connected_components(const Graph& graph) {
     CharDegreeMap indices;
     CharDegreeMap lowlinks;
     CharSet on_stack;
     CharStack stack;
-    std::qvector<std::qvector<char>> components;
+    qpp::qvector<qpp::qvector<char>> components;
     std::size_t index = 0;
 
-    std::qvector<char> nodes;
+    qpp::qvector<char> nodes;
     nodes.reserve(graph.size());
     for (const auto& [node, _] : graph)
         nodes.push_back(node);
@@ -140,7 +140,7 @@ inline std::qvector<std::qvector<char>> strongly_connected_components(const Grap
     return components;
 }
 
-inline AlienDictionaryResult alien_dictionary(const std::qvector<std::string>& words) {
+inline AlienDictionaryResult alien_dictionary(const qpp::qvector<std::string>& words) {
     AlienDictionaryResult result{};
 
     const auto analysis = build_dependency_graph(words);
@@ -168,7 +168,7 @@ inline AlienDictionaryResult alien_dictionary(const std::qvector<std::string>& w
         ++processed;
 
         if (const auto it = analysis.adjacency.find(node); it != analysis.adjacency.end()) {
-            std::qvector<char> neighbors(it->second.begin(), it->second.end());
+            qpp::qvector<char> neighbors(it->second.begin(), it->second.end());
             std::sort(neighbors.begin(), neighbors.end());
             for (const auto neighbor : neighbors) {
                 auto& degree = indegree[neighbor];
@@ -188,7 +188,7 @@ inline AlienDictionaryResult alien_dictionary(const std::qvector<std::string>& w
     return result;
 }
 
-inline std::string describe_components(const std::qvector<std::qvector<char>>& components) {
+inline std::string describe_components(const qpp::qvector<qpp::qvector<char>>& components) {
     std::string description;
     bool first_component = true;
     for (const auto& component : components) {

--- a/examples/data-structures-and-algorithms/advanced-graphs/alien_dictionary.qpp
+++ b/examples/data-structures-and-algorithms/advanced-graphs/alien_dictionary.qpp
@@ -9,7 +9,7 @@
 using qpp::examples::advanced_graphs::alien_dictionary;
 using qpp::examples::advanced_graphs::AlienDictionaryResult;
 
-void print_result(const std::qvector<std::string>& words, const AlienDictionaryResult& result) {
+void print_result(const qpp::qvector<std::string>& words, const AlienDictionaryResult& result) {
     std::vector<std::string> classical_words(words.begin(), words.end());
 
     std::cout << "Words: [";
@@ -60,10 +60,10 @@ void print_result(const std::qvector<std::string>& words, const AlienDictionaryR
 }
 
 int main() {
-    std::qvector<std::string> canonical{"wrt", "wrf", "er", "ett", "rftt"};
-    std::qvector<std::string> ambiguous{"z", "x", "a", "za"};
-    std::qvector<std::string> cyclic{"z", "x", "z"};
-    std::qvector<std::string> prefix_conflict{"abc", "ab"};
+    qpp::qvector<std::string> canonical{"wrt", "wrf", "er", "ett", "rftt"};
+    qpp::qvector<std::string> ambiguous{"z", "x", "a", "za"};
+    qpp::qvector<std::string> cyclic{"z", "x", "z"};
+    qpp::qvector<std::string> prefix_conflict{"abc", "ab"};
 
     print_result(canonical, alien_dictionary(canonical));
     print_result(ambiguous, alien_dictionary(ambiguous));

--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.hpp
@@ -130,7 +130,7 @@ private:
 ///     Bottle neck
 
 /// Return true when the input contains any duplicate values.
-inline bool contains_duplicates(const std::qvector<qint>& list) {
+inline bool contains_duplicates(const qpp::qvector<qint>& list) {
     std::entangled_set<int> visited;
     visited.reserve(list.size());
     for (const auto& item : list) {
@@ -164,7 +164,7 @@ inline bool valid_anagram(std::string_view s, std::string_view t) {
 }
 
 /// Return the indices of two quantum values whose collapsed scalars sum to the target.
-inline std::pair<int, int> two_sum(const std::qvector<qint>& nums,
+inline std::pair<int, int> two_sum(const qpp::qvector<qint>& nums,
                                            int target) {
     int value = 0;
     int complement = 0;
@@ -266,17 +266,17 @@ inline std::vector<std::string> decode(const std::string& data) {
 
 
 /// Collapse each quantum value to a scalar and compute the product excluding each index.
-inline std::qvector<int> product_except_self(const std::qvector<qint>& nums) {
+inline qpp::qvector<int> product_except_self(const qpp::qvector<qint>& nums) {
     const std::size_t n = nums.size();
     if (n == 0)
         return {};
 
-    std::qvector<int> classical_values;
+    qpp::qvector<int> classical_values;
     classical_values.reserve(n);
     for (const auto& value : nums)
         classical_values.push_back(detail::collapse_to_scalar(value));
 
-    std::qvector<int> result(n, 1);
+    qpp::qvector<int> result(n, 1);
     int prefix = 1;
     for (std::size_t i = 0; i < n; ++i) {
         result[i] = prefix;

--- a/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
+++ b/examples/data-structures-and-algorithms/arrays-and-hashing/arrays_and_hashing.qpp
@@ -89,7 +89,7 @@ int main() {
     std::cout << std::boolalpha;
 
     const auto to_quantum = [](const std::vector<int>& classical_values) {
-        std::qvector<::qint> quantum_values;
+        qpp::qvector<::qint> quantum_values;
         quantum_values.reserve(classical_values.size());
         for (int value : classical_values)
             quantum_values.emplace_back(::qint{value, value, value, value});

--- a/examples/data-structures-and-algorithms/backtracking/backtracking.hpp
+++ b/examples/data-structures-and-algorithms/backtracking/backtracking.hpp
@@ -20,10 +20,10 @@ inline std::size_t encode_position(std::size_t row, std::size_t col,
     return row * cols + col;
 }
 
-inline void combination_sum_dfs(const std::qvector<int>& candidates,
+inline void combination_sum_dfs(const qpp::qvector<int>& candidates,
                                 int target, std::size_t index,
-                                std::qvector<int>& combination,
-                                std::qvector<std::qvector<int>>& result) {
+                                qpp::qvector<int>& combination,
+                                qpp::qvector<qpp::qvector<int>>& result) {
     if (target == 0) {
         result.push_back(combination);
         return;
@@ -40,7 +40,7 @@ inline void combination_sum_dfs(const std::qvector<int>& candidates,
     }
 }
 
-inline bool word_search_dfs(const std::qvector<std::qvector<char>>& board,
+inline bool word_search_dfs(const qpp::qvector<qpp::qvector<char>>& board,
                             std::string_view word, std::size_t depth, int row,
                             int col, std::entangled_set<std::size_t>& visited,
                             std::size_t cols) {
@@ -82,8 +82,8 @@ inline bool word_search_dfs(const std::qvector<std::qvector<char>>& board,
 /// The candidates are deduplicated and sorted internally. Each value can be
 /// used unlimited times. The algorithm performs a depth-first search while
 /// pruning branches whenever the partial sum would exceed the target.
-[[nodiscard]] inline std::qvector<std::qvector<int>>
-combination_sum(std::qvector<int> candidates, int target) {
+[[nodiscard]] inline qpp::qvector<qpp::qvector<int>>
+combination_sum(qpp::qvector<int> candidates, int target) {
     if (target < 0)
         return {};
 
@@ -95,8 +95,8 @@ combination_sum(std::qvector<int> candidates, int target) {
     candidates.assign(unique_candidates.begin(), unique_candidates.end());
     std::sort(candidates.begin(), candidates.end());
 
-    std::qvector<std::qvector<int>> result;
-    std::qvector<int> combination;
+    qpp::qvector<qpp::qvector<int>> result;
+    qpp::qvector<int> combination;
     detail::combination_sum_dfs(candidates, target, 0, combination, result);
     return result;
 }
@@ -106,7 +106,7 @@ combination_sum(std::qvector<int> candidates, int target) {
 /// Returns `true` when the word can be formed without revisiting cells. The
 /// recursion explores neighbours starting from every matching cell on the grid.
 [[nodiscard]] inline bool word_search(
-    const std::qvector<std::qvector<char>>& board, std::string_view word) {
+    const qpp::qvector<qpp::qvector<char>>& board, std::string_view word) {
     if (word.empty())
         return true;
     if (board.empty() || board.front().empty())
@@ -140,7 +140,7 @@ combination_sum(std::qvector<int> candidates, int target) {
 /// is primarily useful when integrating classical search results with quantum
 /// control logic inside QPP examples.
 [[nodiscard]] inline qpp::pbool word_search_probability(
-    const std::qvector<std::qvector<char>>& board, std::string_view word) {
+    const qpp::qvector<qpp::qvector<char>>& board, std::string_view word) {
     qpp::qclass indicator(1);
     if (word_search(board, word))
         indicator.apply_x(0);

--- a/examples/data-structures-and-algorithms/backtracking/backtracking.qpp
+++ b/examples/data-structures-and-algorithms/backtracking/backtracking.qpp
@@ -7,7 +7,7 @@
 
 namespace {
 
-void print_combinations(const std::qvector<std::qvector<int>>& combos) {
+void print_combinations(const qpp::qvector<qpp::qvector<int>>& combos) {
     std::cout << "Found " << combos.size() << " combinations:\n";
     for (const auto& combo : combos) {
         std::cout << "  [";
@@ -20,7 +20,7 @@ void print_combinations(const std::qvector<std::qvector<int>>& combos) {
     }
 }
 
-void print_board(const std::qvector<std::qvector<char>>& board) {
+void print_board(const qpp::qvector<qpp::qvector<char>>& board) {
     std::cout << "Board:\n";
     for (const auto& row : board) {
         for (char cell : row)
@@ -34,13 +34,13 @@ void print_board(const std::qvector<std::qvector<char>>& board) {
 int main() {
     using namespace qpp::examples::backtracking;
 
-    const std::qvector<int> candidates{2, 3, 6, 7};
+    const qpp::qvector<int> candidates{2, 3, 6, 7};
     const int target = 7;
     std::cout << "combination_sum([2,3,6,7], 7)\n";
     auto combos = combination_sum(candidates, target);
     print_combinations(combos);
 
-    std::qvector<std::qvector<char>> board{{'A', 'B', 'C', 'E'},
+    qpp::qvector<qpp::qvector<char>> board{{'A', 'B', 'C', 'E'},
                                            {'S', 'F', 'C', 'S'},
                                            {'A', 'D', 'E', 'E'}};
     print_board(board);

--- a/examples/data-structures-and-algorithms/binary-search/binary_search.hpp
+++ b/examples/data-structures-and-algorithms/binary-search/binary_search.hpp
@@ -25,9 +25,9 @@ inline int measure_value(const qint& value) {
 namespace detail {
 
 /// Measure every register component so downstream code can act on classical data.
-inline std::qvector<qint>
-collapse_rotated_array_inputs(const std::qvector<qint>& nums) {
-    std::qvector<qint> collapsed;
+inline qpp::qvector<qint>
+collapse_rotated_array_inputs(const qpp::qvector<qint>& nums) {
+    qpp::qvector<qint> collapsed;
     collapsed.reserve(nums.size());
 
     for (const auto& value : nums) {
@@ -53,7 +53,7 @@ collapse_rotated_array_inputs(const std::qvector<qint>& nums) {
 } // namespace detail
 
 /// Locate the minimum element of a rotated sorted array of qints.
-inline int find_min_in_rotated_sorted_array(const std::qvector<qint>& nums) {
+inline int find_min_in_rotated_sorted_array(const qpp::qvector<qint>& nums) {
     if (nums.empty())
         return 0;
 
@@ -84,7 +84,7 @@ inline int find_min_in_rotated_sorted_array(const std::qvector<qint>& nums) {
 }
 
 /// Search for a target element in a rotated sorted array of qints.
-inline int search_in_rotated_sorted_array(const std::qvector<qint>& nums,
+inline int search_in_rotated_sorted_array(const qpp::qvector<qint>& nums,
                                                   int target) {
     if (nums.empty())
         return -1;
@@ -120,13 +120,13 @@ inline int search_in_rotated_sorted_array(const std::qvector<qint>& nums,
 
 /// Quantum wrapper that collapses inputs before invoking the classical minimum search.
 inline int
-quantum_find_min_in_rotated_sorted_array(const std::qvector<qint>& nums) {
+quantum_find_min_in_rotated_sorted_array(const qpp::qvector<qint>& nums) {
     const auto collapsed = detail::collapse_rotated_array_inputs(nums);
     return find_min_in_rotated_sorted_array(collapsed);
 }
 
 /// Quantum wrapper that measures inputs then delegates to the classical search routine.
-inline int quantum_search_in_rotated_sorted_array(const std::qvector<qint>& nums,
+inline int quantum_search_in_rotated_sorted_array(const qpp::qvector<qint>& nums,
                                                   int target) {
     const auto collapsed = detail::collapse_rotated_array_inputs(nums);
     return search_in_rotated_sorted_array(collapsed, target);

--- a/examples/data-structures-and-algorithms/binary-search/binary_search.qpp
+++ b/examples/data-structures-and-algorithms/binary-search/binary_search.qpp
@@ -39,7 +39,7 @@ int main() {
     std::cout << "search_in_rotated_sorted_array([4,5,6,7,0,1,2], 3) -> "
               << search_in_rotated_sorted_array(rotated, 3) << "\n";
 
-    const std::qvector<::qint> quantum_rotated{4, 5, 6, 7, 0, 1, 2};
+    const qpp::qvector<::qint> quantum_rotated{4, 5, 6, 7, 0, 1, 2};
     std::cout << "quantum_find_min_in_rotated_sorted_array([4,5,6,7,0,1,2]) -> "
               << quantum_find_min_in_rotated_sorted_array(quantum_rotated) << "\n";
     std::cout << "quantum_search_in_rotated_sorted_array([4,5,6,7,0,1,2], 6) -> "

--- a/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
+++ b/examples/data-structures-and-algorithms/bit-manipulation/bit_manipulation.hpp
@@ -68,7 +68,7 @@ inline qint build_from_signed(int value) {
     return build_from_bits(bits);
 }
 
-inline std::vector<int> collapse_vector(const std::qvector<qint>& values) {
+inline std::vector<int> collapse_vector(const qpp::qvector<qint>& values) {
     std::vector<int> result;
     result.reserve(values.size());
     for (const auto& value : values)
@@ -76,8 +76,8 @@ inline std::vector<int> collapse_vector(const std::qvector<qint>& values) {
     return result;
 }
 
-inline std::qvector<qint> build_vector(const std::vector<int>& values) {
-    std::qvector<qint> result;
+inline qpp::qvector<qint> build_vector(const std::vector<int>& values) {
+    qpp::qvector<qint> result;
     result.reserve(values.size());
     for (int value : values)
         result.push_back(build_from_signed(value));
@@ -125,15 +125,15 @@ inline std::vector<int> classical_counting_bits(int n) {
 }
 
 /// Compute population counts for the range [0, n] and encode them as quantum integers.
-inline std::qvector<qint> counting_bits(int n) {
+inline qpp::qvector<qint> counting_bits(int n) {
     const auto classical_counts = classical_counting_bits(n);
     return detail::build_vector(classical_counts);
 }
 
 /// Compute population counts for the range [0, n] and encode them as quantum integers.
-inline std::qvector<qint> quantum_counting_bits(int n) { return counting_bits(n); }
+inline qpp::qvector<qint> quantum_counting_bits(int n) { return counting_bits(n); }
 
-inline std::qvector<qint> quantum_counting_bits(std::uint32_t n) {
+inline qpp::qvector<qint> quantum_counting_bits(std::uint32_t n) {
     return quantum_counting_bits(static_cast<int>(n));
 }
 
@@ -166,7 +166,7 @@ inline int missing_number(const std::vector<int>& nums) {
 }
 
 /// Return the missing value in the quantum variant of the problem.
-inline qint missing_number(const std::qvector<qint>& nums) {
+inline qint missing_number(const qpp::qvector<qint>& nums) {
     const auto classical = detail::collapse_vector(nums);
     return detail::build_from_signed(missing_number(classical));
 }
@@ -235,7 +235,7 @@ inline qint quantum_reverse_bits(std::uint32_t value) {
     return quantum_reverse_bits(make_quantum_from_uint32(value));
 }
 
-inline qint quantum_missing_number(const std::qvector<qint>& nums) {
+inline qint quantum_missing_number(const qpp::qvector<qint>& nums) {
     return missing_number(nums);
 }
 

--- a/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.hpp
+++ b/examples/data-structures-and-algorithms/dynamic-programming-2d/dynamic_programming_2d.hpp
@@ -21,7 +21,7 @@ inline qpp::pbool unique_paths(int m, int n) {
     if (m <= 0 || n <= 0)
         return qpp::pbool{0.0};
 
-    std::qvector<int> dp(static_cast<std::size_t>(n), 1);
+    qpp::qvector<int> dp(static_cast<std::size_t>(n), 1);
     for (int row = 1; row < m; ++row) {
         for (int col = 1; col < n; ++col)
             dp[static_cast<std::size_t>(col)] +=
@@ -50,7 +50,7 @@ longest_common_subsequence(std::string_view first, std::string_view second) {
     const std::size_t rows = first.size();
     const std::size_t cols = second.size();
 
-    std::qvector<qpp::qdp::quantum_sequence<int>> dp;
+    qpp::qvector<qpp::qdp::quantum_sequence<int>> dp;
     dp.reserve(rows + 1);
     for (std::size_t i = 0; i <= rows; ++i)
         dp.emplace_back(cols + 1, 0);

--- a/examples/data-structures-and-algorithms/graph/graph_problems.hpp
+++ b/examples/data-structures-and-algorithms/graph/graph_problems.hpp
@@ -12,7 +12,7 @@ namespace qpp::examples::graph {
 
 struct Node {
     int value{};
-    std::qvector<Node*> neighbors{};
+    qpp::qvector<Node*> neighbors{};
 };
 
 using NodeCloneMap =
@@ -21,8 +21,8 @@ using NodeCloneMap =
 namespace detail {
 inline constexpr int kDirections[4][2] = {{1, 0}, {-1, 0}, {0, 1}, {0, -1}};
 
-inline void dfs_islands(const std::qvector<std::qvector<char>>& grid,
-                        std::qvector<std::qvector<bool>>& visited, int row,
+inline void dfs_islands(const qpp::qvector<qpp::qvector<char>>& grid,
+                        qpp::qvector<qpp::qvector<bool>>& visited, int row,
                         int col) {
     const int rows = static_cast<int>(grid.size());
     const int cols = static_cast<int>(grid.front().size());
@@ -51,8 +51,8 @@ inline void dfs_clone(Node* node, NodeCloneMap& clones) {
 }
 
 inline void dfs_flow(int row, int col,
-                     const std::qvector<std::qvector<int>>& heights,
-                     std::qvector<std::qvector<bool>>& reachable) {
+                     const qpp::qvector<qpp::qvector<int>>& heights,
+                     qpp::qvector<qpp::qvector<bool>>& reachable) {
     if (reachable[row][col])
         return;
 
@@ -73,14 +73,14 @@ inline void dfs_flow(int row, int col,
 } // namespace detail
 
 inline std::size_t count_islands(
-    const std::qvector<std::qvector<char>>& grid) {
+    const qpp::qvector<qpp::qvector<char>>& grid) {
     if (grid.empty() || grid.front().empty())
         return 0;
 
     const int rows = static_cast<int>(grid.size());
     const int cols = static_cast<int>(grid.front().size());
-    std::qvector<std::qvector<bool>> visited(static_cast<std::size_t>(rows),
-                                            std::qvector<bool>(static_cast<std::size_t>(cols)));
+    qpp::qvector<qpp::qvector<bool>> visited(static_cast<std::size_t>(rows),
+                                            qpp::qvector<bool>(static_cast<std::size_t>(cols)));
     std::size_t islands = 0;
 
     for (int row = 0; row < rows; ++row) {
@@ -105,17 +105,17 @@ inline Node* clone_graph(Node* node) {
     return clones[node];
 }
 
-inline std::qvector<std::pair<int, int>> pacific_atlantic(
-    const std::qvector<std::qvector<int>>& heights) {
+inline qpp::qvector<std::pair<int, int>> pacific_atlantic(
+    const qpp::qvector<qpp::qvector<int>>& heights) {
     if (heights.empty() || heights.front().empty())
         return {};
 
     const int rows = static_cast<int>(heights.size());
     const int cols = static_cast<int>(heights.front().size());
-    std::qvector<std::qvector<bool>> pacific(static_cast<std::size_t>(rows),
-                                             std::qvector<bool>(static_cast<std::size_t>(cols)));
-    std::qvector<std::qvector<bool>> atlantic(static_cast<std::size_t>(rows),
-                                              std::qvector<bool>(static_cast<std::size_t>(cols)));
+    qpp::qvector<qpp::qvector<bool>> pacific(static_cast<std::size_t>(rows),
+                                             qpp::qvector<bool>(static_cast<std::size_t>(cols)));
+    qpp::qvector<qpp::qvector<bool>> atlantic(static_cast<std::size_t>(rows),
+                                              qpp::qvector<bool>(static_cast<std::size_t>(cols)));
 
     for (int col = 0; col < cols; ++col) {
         detail::dfs_flow(0, col, heights, pacific);
@@ -127,7 +127,7 @@ inline std::qvector<std::pair<int, int>> pacific_atlantic(
         detail::dfs_flow(row, cols - 1, heights, atlantic);
     }
 
-    std::qvector<std::pair<int, int>> result;
+    qpp::qvector<std::pair<int, int>> result;
     result.reserve(static_cast<std::size_t>(rows * cols));
     for (int row = 0; row < rows; ++row) {
         for (int col = 0; col < cols; ++col) {
@@ -140,12 +140,12 @@ inline std::qvector<std::pair<int, int>> pacific_atlantic(
 }
 
 inline bool can_finish_courses(
-    int num_courses, const std::qvector<std::pair<int, int>>& prerequisites) {
+    int num_courses, const qpp::qvector<std::pair<int, int>>& prerequisites) {
     if (num_courses <= 0)
         return prerequisites.empty();
 
-    std::qvector<std::qvector<int>> graph(static_cast<std::size_t>(num_courses));
-    std::qvector<int> indegree(static_cast<std::size_t>(num_courses), 0);
+    qpp::qvector<qpp::qvector<int>> graph(static_cast<std::size_t>(num_courses));
+    qpp::qvector<int> indegree(static_cast<std::size_t>(num_courses), 0);
     for (const auto& [course, prereq] : prerequisites) {
         if (course < 0 || course >= num_courses || prereq < 0 ||
             prereq >= num_courses)
@@ -155,7 +155,7 @@ inline bool can_finish_courses(
         ++indegree[course];
     }
 
-    std::qvector<int> queue;
+    qpp::qvector<int> queue;
     queue.reserve(static_cast<std::size_t>(num_courses));
     for (int course = 0; course < num_courses; ++course) {
         if (indegree[static_cast<std::size_t>(course)] == 0)
@@ -179,14 +179,14 @@ inline bool can_finish_courses(
 }
 
 inline bool is_valid_tree(int n,
-                          const std::qvector<std::pair<int, int>>& edges) {
+                          const qpp::qvector<std::pair<int, int>>& edges) {
     if (n <= 0)
         return false;
 
     if (edges.size() != static_cast<std::size_t>(n - 1))
         return false;
 
-    std::qvector<std::qvector<int>> graph(static_cast<std::size_t>(n));
+    qpp::qvector<qpp::qvector<int>> graph(static_cast<std::size_t>(n));
     for (const auto& [u, v] : edges) {
         if (u < 0 || u >= n || v < 0 || v >= n)
             return false;
@@ -195,8 +195,8 @@ inline bool is_valid_tree(int n,
         graph[v].push_back(u);
     }
 
-    std::qvector<bool> visited(static_cast<std::size_t>(n), false);
-    std::qvector<int> queue;
+    qpp::qvector<bool> visited(static_cast<std::size_t>(n), false);
+    qpp::qvector<int> queue;
     queue.push_back(0);
     visited[0] = true;
 
@@ -218,11 +218,11 @@ inline bool is_valid_tree(int n,
 }
 
 inline int count_components(
-    int n, const std::qvector<std::pair<int, int>>& edges) {
+    int n, const qpp::qvector<std::pair<int, int>>& edges) {
     if (n <= 0)
         return 0;
 
-    std::qvector<std::qvector<int>> graph(static_cast<std::size_t>(n));
+    qpp::qvector<qpp::qvector<int>> graph(static_cast<std::size_t>(n));
     for (const auto& [u, v] : edges) {
         if (u < 0 || u >= n || v < 0 || v >= n)
             continue;
@@ -231,8 +231,8 @@ inline int count_components(
         graph[v].push_back(u);
     }
 
-    std::qvector<bool> visited(static_cast<std::size_t>(n), false);
-    std::qvector<int> queue;
+    qpp::qvector<bool> visited(static_cast<std::size_t>(n), false);
+    qpp::qvector<int> queue;
     int components = 0;
 
     for (int node = 0; node < n; ++node) {

--- a/examples/data-structures-and-algorithms/graph/graph_problems.qpp
+++ b/examples/data-structures-and-algorithms/graph/graph_problems.qpp
@@ -38,14 +38,14 @@ void delete_graph(Node* node) {
 } // namespace
 
 int main() {
-    const std::qvector<std::qvector<char>> island_grid{{'1', '1', '0', '0', '0'},
+    const qpp::qvector<qpp::qvector<char>> island_grid{{'1', '1', '0', '0', '0'},
                                                        {'1', '1', '0', '0', '0'},
                                                        {'0', '0', '1', '0', '0'},
                                                        {'0', '0', '0', '1', '1'}};
     std::cout << "Number of Islands\n  count: " << count_islands(island_grid)
               << "\n\n";
 
-    std::qvector<std::unique_ptr<Node>> original;
+    qpp::qvector<std::unique_ptr<Node>> original;
     for (int value = 1; value <= 4; ++value)
         original.push_back(std::make_unique<Node>(Node{value, {}}));
 
@@ -64,7 +64,7 @@ int main() {
     std::cout << "\n\n";
     delete_graph(cloned);
 
-    const std::qvector<std::qvector<int>> heights{{1, 2, 2, 3, 5},
+    const qpp::qvector<qpp::qvector<int>> heights{{1, 2, 2, 3, 5},
                                                   {3, 2, 3, 4, 4},
                                                   {2, 4, 5, 3, 1},
                                                   {6, 7, 1, 4, 5},
@@ -77,18 +77,18 @@ int main() {
         std::cout << " (" << row << ", " << col << ')';
     std::cout << "\n\n";
 
-    const std::qvector<std::pair<int, int>> prerequisites{{1, 0}, {2, 1},
+    const qpp::qvector<std::pair<int, int>> prerequisites{{1, 0}, {2, 1},
                                                            {3, 2}};
     std::cout << std::boolalpha;
     std::cout << "Course Schedule\n  can_finish: "
               << can_finish_courses(4, prerequisites) << "\n\n";
 
-    const std::qvector<std::pair<int, int>> tree_edges{{0, 1}, {0, 2},
+    const qpp::qvector<std::pair<int, int>> tree_edges{{0, 1}, {0, 2},
                                                        {0, 3}, {1, 4}};
     std::cout << "Graph Valid Tree\n  is_tree: "
               << is_valid_tree(5, tree_edges) << "\n\n";
 
-    const std::qvector<std::pair<int, int>> component_edges{{0, 1}, {1, 2},
+    const qpp::qvector<std::pair<int, int>> component_edges{{0, 1}, {1, 2},
                                                             {3, 4}};
     std::cout << "Number of Connected Components\n  components: "
               << count_components(5, component_edges) << '\n';

--- a/examples/data-structures-and-algorithms/greedy/greedy.hpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.hpp
@@ -36,7 +36,7 @@ inline int collapse_to_scalar(const qint& value) {
 } // namespace detail
 
 /// Return the maximum sum obtainable from a contiguous subarray.
-inline int maximum_subarray(const std::qvector<qint>& nums) {
+inline int maximum_subarray(const qpp::qvector<qint>& nums) {
     if (nums.empty())
         return 0;
 
@@ -53,7 +53,7 @@ inline int maximum_subarray(const std::qvector<qint>& nums) {
 
 
 /// Determine whether it is possible to reach the last index.
-inline bool can_jump(const std::qvector<qint>& nums) {
+inline bool can_jump(const qpp::qvector<qint>& nums) {
     const auto collapse_step = [](const qint& value) {
         return detail::collapse_to_scalar(value);
     };
@@ -72,7 +72,7 @@ inline bool can_jump(const std::qvector<qint>& nums) {
 }
 
 /// Build a register encoding reachable prefixes for the jump game instance.
-inline qpp::qclass reachable_prefix_superposition(const std::qvector<qint>& nums) {
+inline qpp::qclass reachable_prefix_superposition(const qpp::qvector<qint>& nums) {
     const std::size_t n = nums.size();
     std::size_t qubits = 0;
     while ((std::size_t{1} << qubits) < std::max<std::size_t>(n, 1))

--- a/examples/data-structures-and-algorithms/greedy/greedy.qpp
+++ b/examples/data-structures-and-algorithms/greedy/greedy.qpp
@@ -32,7 +32,7 @@ int main() {
     using namespace qpp::examples::greedy;
 
     const auto to_quantum = [](const auto& classical_values) {
-        std::qvector<::qint> quantum_values;
+        qpp::qvector<::qint> quantum_values;
         quantum_values.reserve(classical_values.size());
         for (int value : classical_values) {
             const int sign = value >= 0 ? 1 : -1;

--- a/examples/data-structures-and-algorithms/intervals/intervals.hpp
+++ b/examples/data-structures-and-algorithms/intervals/intervals.hpp
@@ -38,7 +38,7 @@ inline classical_interval collapse_interval(const quantum_interval& interval) {
 }
 
 inline std::vector<classical_interval>
-collapse_intervals(const std::qvector<quantum_interval>& intervals) {
+collapse_intervals(const qpp::qvector<quantum_interval>& intervals) {
     std::vector<classical_interval> collapsed;
     collapsed.reserve(intervals.size());
     for (const auto& interval : intervals)
@@ -55,9 +55,9 @@ inline quantum_interval expand_interval(const classical_interval& interval) {
                             make_endpoint(interval.end)};
 }
 
-inline std::qvector<quantum_interval>
+inline qpp::qvector<quantum_interval>
 expand_intervals(const std::vector<classical_interval>& intervals) {
-    std::qvector<quantum_interval> expanded;
+    qpp::qvector<quantum_interval> expanded;
     expanded.reserve(intervals.size());
     for (const auto& interval : intervals)
         expanded.push_back(expand_interval(interval));
@@ -67,8 +67,8 @@ expand_intervals(const std::vector<classical_interval>& intervals) {
 } // namespace detail
 
 /// Insert a new interval into a sorted list of disjoint intervals.
-inline std::qvector<quantum_interval>
-insert_interval(const std::qvector<quantum_interval>& intervals,
+inline qpp::qvector<quantum_interval>
+insert_interval(const qpp::qvector<quantum_interval>& intervals,
                 const quantum_interval& new_interval) {
     const auto collapsed = detail::collapse_intervals(intervals);
     detail::classical_interval merged_new = detail::collapse_interval(new_interval);
@@ -101,8 +101,8 @@ insert_interval(const std::qvector<quantum_interval>& intervals,
 }
 
 /// Merge all overlapping intervals.
-inline std::qvector<quantum_interval>
-merge_intervals(const std::qvector<quantum_interval>& intervals) {
+inline qpp::qvector<quantum_interval>
+merge_intervals(const qpp::qvector<quantum_interval>& intervals) {
     auto collapsed = detail::collapse_intervals(intervals);
     if (collapsed.empty())
         return {};
@@ -133,7 +133,7 @@ merge_intervals(const std::qvector<quantum_interval>& intervals) {
 
 /// Minimum number of intervals to remove so that the remainder do not overlap.
 inline int
-erase_overlap_intervals(const std::qvector<quantum_interval>& intervals) {
+erase_overlap_intervals(const qpp::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return 0;
 
@@ -162,7 +162,7 @@ erase_overlap_intervals(const std::qvector<quantum_interval>& intervals) {
 
 /// Determine whether all meetings can be attended without overlaps.
 inline bool
-can_attend_all_meetings(const std::qvector<quantum_interval>& intervals) {
+can_attend_all_meetings(const qpp::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return true;
 
@@ -184,7 +184,7 @@ can_attend_all_meetings(const std::qvector<quantum_interval>& intervals) {
 }
 
 /// Minimum number of meeting rooms required to host all intervals.
-inline int min_meeting_rooms(const std::qvector<quantum_interval>& intervals) {
+inline int min_meeting_rooms(const qpp::qvector<quantum_interval>& intervals) {
     if (intervals.empty())
         return 0;
 
@@ -222,7 +222,7 @@ inline int min_meeting_rooms(const std::qvector<quantum_interval>& intervals) {
 }
 
 /// Probability bias describing how likely a random pair of intervals overlaps.
-inline qpp::pbool conflict_bias(const std::qvector<quantum_interval>& intervals) {
+inline qpp::pbool conflict_bias(const qpp::qvector<quantum_interval>& intervals) {
     if (intervals.size() < 2)
         return qpp::pbool{0.0};
 

--- a/examples/data-structures-and-algorithms/intervals/intervals.qpp
+++ b/examples/data-structures-and-algorithms/intervals/intervals.qpp
@@ -27,7 +27,7 @@ void print_state(const qpp::qstruct& state, const std::string& label) {
 }
 
 void print_intervals(
-    const std::qvector<qpp::examples::intervals::quantum_interval>& intervals,
+    const qpp::qvector<qpp::examples::intervals::quantum_interval>& intervals,
     const std::string& label) {
     const auto collapsed =
         qpp::examples::intervals::detail::collapse_intervals(intervals);
@@ -45,7 +45,7 @@ int main() {
     using namespace qpp::examples::intervals;
 
     const auto to_quantum = [](const std::vector<std::pair<int, int>>& classical) {
-        std::qvector<quantum_interval> quantum;
+        qpp::qvector<quantum_interval> quantum;
         quantum.reserve(classical.size());
         for (const auto& bounds : classical) {
             const detail::classical_interval collapsed{bounds.first, bounds.second};
@@ -60,7 +60,7 @@ int main() {
     const auto new_interval = to_quantum(classical_new).front();
     const auto inserted = insert_interval(initial, new_interval);
     print_intervals(initial, "insert_interval input:");
-    print_intervals(std::qvector<quantum_interval>{new_interval}, "new interval:");
+    print_intervals(qpp::qvector<quantum_interval>{new_interval}, "new interval:");
     print_intervals(inserted, "insert_interval output:");
 
     const std::vector<std::pair<int, int>> classical_to_merge{{1, 4},

--- a/examples/data-structures-and-algorithms/linked-list/README.md
+++ b/examples/data-structures-and-algorithms/linked-list/README.md
@@ -2,7 +2,7 @@
 
 This example upgrades the classical linked list exercises to operate on the
 project's quantum data structures.  Each node stores a [`qint`](../../../include/qpp/qint)
-payload and traversal utilities return `std::qvector` containers so that
+payload and traversal utilities return `qpp::qvector` containers so that
 algorithms can remain quantum-aware while still collapsing values for
 presentation.
 

--- a/examples/data-structures-and-algorithms/linked-list/linked_list_problems.hpp
+++ b/examples/data-structures-and-algorithms/linked-list/linked_list_problems.hpp
@@ -56,7 +56,7 @@ inline NodePtr make_node(int value, NodePtr next = nullptr) {
     return make_node(make_quantum_value(value), std::move(next));
 }
 
-inline NodePtr make_list(std::qvector<qint> values) {
+inline NodePtr make_list(qpp::qvector<qint> values) {
     if (values.empty())
         return nullptr;
 
@@ -72,7 +72,7 @@ inline NodePtr make_list(std::qvector<qint> values) {
 }
 
 inline NodePtr make_list(const std::vector<int>& values) {
-    std::qvector<qint> quantum_values;
+    qpp::qvector<qint> quantum_values;
     quantum_values.reserve(values.size());
     for (int value : values)
         quantum_values.emplace_back(make_quantum_value(value));
@@ -83,10 +83,10 @@ inline NodePtr make_list(std::initializer_list<int> values) {
     return make_list(std::vector<int>(values));
 }
 
-inline std::qvector<qint> to_vector(const NodePtr& head,
+inline qpp::qvector<qint> to_vector(const NodePtr& head,
                                     std::size_t max_nodes = 64,
                                     bool* truncated = nullptr) {
-    std::qvector<qint> values;
+    qpp::qvector<qint> values;
     values.reserve(max_nodes);
 
     std::entangled_set<const ListNode*> visited_nodes;
@@ -240,14 +240,14 @@ inline NodePtr remove_nth_from_end(NodePtr head, int n) {
     return dummy->next;
 }
 
-inline NodePtr merge_k_sorted_lists(std::qvector<NodePtr> lists) {
+inline NodePtr merge_k_sorted_lists(qpp::qvector<NodePtr> lists) {
     struct NodePtrCompare {
         bool operator()(const NodePtr& lhs, const NodePtr& rhs) const {
             return collapse_value(lhs->value) > collapse_value(rhs->value);
         }
     };
 
-    std::priority_queue<NodePtr, std::qvector<NodePtr>, NodePtrCompare> heap;
+    std::priority_queue<NodePtr, qpp::qvector<NodePtr>, NodePtrCompare> heap;
     for (auto& list : lists)
         if (list)
             heap.push(list);

--- a/examples/data-structures-and-algorithms/linked-list/linked_list_problems.qpp
+++ b/examples/data-structures-and-algorithms/linked-list/linked_list_problems.qpp
@@ -72,7 +72,7 @@ int main() {
     std::cout << "Remove Nth Node From End of List\n  result: "
               << describe_list(removal_example) << "\n\n";
 
-    std::qvector<NodePtr> merged_inputs{
+    qpp::qvector<NodePtr> merged_inputs{
         make_list({1, 4, 7}), make_list({2, 5, 8}), make_list({3, 6, 9})};
     const auto merged_k = merge_k_sorted_lists(merged_inputs);
     std::cout << "Merge K Sorted Lists\n  result: " << describe_list(merged_k)

--- a/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.hpp
+++ b/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.hpp
@@ -13,7 +13,7 @@ namespace qpp::examples::math_and_geometry {
 /// outer ring is swapped into its rotated position using temporary storage
 /// for the four involved values. The process is then repeated for the next
 /// inner ring until the center of the matrix is reached.
-inline void rotate_image(std::qvector<std::qvector<int>>& matrix) {
+inline void rotate_image(qpp::qvector<qpp::qvector<int>>& matrix) {
     const std::size_t n = matrix.size();
     if (n == 0)
         return;
@@ -45,12 +45,12 @@ inline void rotate_image(std::qvector<std::qvector<int>>& matrix) {
 /// The traversal maintains shrinking boundaries for the rows and columns
 /// and iteratively walks along the four directions (right, down, left,
 /// up) until the full matrix has been consumed.
-inline std::qvector<int>
-spiral_matrix(const std::qvector<std::qvector<int>>& matrix) {
+inline qpp::qvector<int>
+spiral_matrix(const qpp::qvector<qpp::qvector<int>>& matrix) {
     if (matrix.empty() || matrix.front().empty())
         return {};
 
-    std::qvector<int> result;
+    qpp::qvector<int> result;
     const std::ptrdiff_t row_count =
         static_cast<std::ptrdiff_t>(matrix.size());
     const std::ptrdiff_t col_count =
@@ -97,7 +97,7 @@ spiral_matrix(const std::qvector<std::qvector<int>>& matrix) {
 /// The implementation uses the first row and column as marker storage to
 /// achieve constant extra space while keeping track of which rows and
 /// columns must be zeroed out.
-inline void set_matrix_zeroes(std::qvector<std::qvector<int>>& matrix) {
+inline void set_matrix_zeroes(qpp::qvector<qpp::qvector<int>>& matrix) {
     if (matrix.empty() || matrix.front().empty())
         return;
 

--- a/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.qpp
+++ b/examples/data-structures-and-algorithms/math-and-geometry/math_and_geometry.qpp
@@ -5,7 +5,7 @@
 #include "math_and_geometry.hpp"
 
 namespace {
-void print_matrix(const std::qvector<std::qvector<int>>& matrix,
+void print_matrix(const qpp::qvector<qpp::qvector<int>>& matrix,
                   const std::string& label) {
     std::cout << label << " (" << matrix.size() << "x"
               << (matrix.empty() ? 0 : matrix.front().size()) << ")\n";
@@ -21,7 +21,7 @@ void print_matrix(const std::qvector<std::qvector<int>>& matrix,
     std::cout << '\n';
 }
 
-void print_vector(const std::qvector<int>& values, const std::string& label) {
+void print_vector(const qpp::qvector<int>& values, const std::string& label) {
     std::cout << label << " -> [";
     for (std::size_t i = 0; i < values.size(); ++i) {
         if (i)
@@ -35,20 +35,20 @@ void print_vector(const std::qvector<int>& values, const std::string& label) {
 int main() {
     using namespace qpp::examples::math_and_geometry;
 
-    std::qvector<std::qvector<int>> rotate_input{{1, 2, 3},
+    qpp::qvector<qpp::qvector<int>> rotate_input{{1, 2, 3},
                                                  {4, 5, 6},
                                                  {7, 8, 9}};
     print_matrix(rotate_input, "Original rotate_image input");
     rotate_image(rotate_input);
     print_matrix(rotate_input, "After rotate_image");
 
-    const std::qvector<std::qvector<int>> spiral_input{{1, 2, 3, 4},
+    const qpp::qvector<qpp::qvector<int>> spiral_input{{1, 2, 3, 4},
                                                        {5, 6, 7, 8},
                                                        {9, 10, 11, 12}};
     const auto spiral = spiral_matrix(spiral_input);
     print_vector(spiral, "spiral_matrix traversal");
 
-    std::qvector<std::qvector<int>> zero_input{{0, 1, 2},
+    qpp::qvector<qpp::qvector<int>> zero_input{{0, 1, 2},
                                                {3, 4, 5},
                                                {6, 0, 7}};
     print_matrix(zero_input, "Original set_matrix_zeroes input");

--- a/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
+++ b/examples/data-structures-and-algorithms/sliding-window/sliding_window.hpp
@@ -19,7 +19,7 @@ namespace qpp::examples::sliding_window {
 
 
 /// Compute the maximum profit achievable with a single buy/sell transaction.
-inline qint best_time_to_buy_and_sell_stock(const std::qvector<qint>& prices) {
+inline qint best_time_to_buy_and_sell_stock(const qpp::qvector<qint>& prices) {
     qint best_profit = 0;
     qint cheapest_so_far = std::numeric_limits<qint>::max();
     for (qint price : prices) {

--- a/examples/data-structures-and-algorithms/stack/stack_problems.hpp
+++ b/examples/data-structures-and-algorithms/stack/stack_problems.hpp
@@ -124,7 +124,7 @@ inline bool is_valid_parentheses(std::string_view s) {
 }
 
 /// Determine whether a sequence of encoded bracket tokens is valid.
-inline bool is_valid_parentheses(const std::qvector<qint>& sequence) {
+inline bool is_valid_parentheses(const qpp::qvector<qint>& sequence) {
     return detail::validate_sequence(sequence.size(),
                                      [&](std::size_t index) {
                                          const auto measured_axes =
@@ -137,7 +137,7 @@ inline bool is_valid_parentheses(const std::qvector<qint>& sequence) {
 }
 
 /// Convenience wrapper that mirrors the quantum-prefixed API used by the sample.
-inline bool quantum_is_valid_parentheses(const std::qvector<qint>& sequence) {
+inline bool quantum_is_valid_parentheses(const qpp::qvector<qint>& sequence) {
     return is_valid_parentheses(sequence);
 }
 
@@ -147,8 +147,8 @@ inline qpp::pbool parentheses_confidence(std::string_view s) {
 }
 
 /// Convert a bracket string into a quantum-friendly encoding of bracket tokens.
-inline std::qvector<qint> encode_parentheses_sequence(std::string_view s) {
-    std::qvector<qint> encoded;
+inline qpp::qvector<qint> encode_parentheses_sequence(std::string_view s) {
+    qpp::qvector<qint> encoded;
     encoded.reserve(s.size());
 
     for (char symbol : s) {
@@ -165,7 +165,7 @@ inline std::qvector<qint> encode_parentheses_sequence(std::string_view s) {
 }
 
 /// Convert an encoded bracket sequence back into its string representation.
-inline std::string decode_parentheses_sequence(const std::qvector<qint>& sequence) {
+inline std::string decode_parentheses_sequence(const qpp::qvector<qint>& sequence) {
     std::string decoded;
     decoded.reserve(sequence.size());
 

--- a/examples/data-structures-and-algorithms/tree/tree_problems.hpp
+++ b/examples/data-structures-and-algorithms/tree/tree_problems.hpp
@@ -53,11 +53,11 @@ inline NodePtr make_node(int value, NodePtr left = nullptr, NodePtr right = null
     return make_node(QuantumLabel::encode(value), std::move(left), std::move(right));
 }
 
-inline NodePtr make_tree(const std::qvector<std::optional<int>>& values) {
+inline NodePtr make_tree(const qpp::qvector<std::optional<int>>& values) {
     if (values.empty() || !values.front())
         return nullptr;
 
-    std::qvector<NodePtr> nodes(values.size());
+    qpp::qvector<NodePtr> nodes(values.size());
     nodes.front() = make_node(*values.front());
 
     for (std::size_t index = 0; index < values.size(); ++index) {
@@ -87,7 +87,7 @@ inline NodePtr make_tree(const std::qvector<std::optional<int>>& values) {
 }
 
 inline NodePtr make_tree(std::initializer_list<std::optional<int>> values) {
-    return make_tree(std::qvector<std::optional<int>>{values});
+    return make_tree(qpp::qvector<std::optional<int>>{values});
 }
 
 inline std::string serialize(const NodePtr& root) {
@@ -95,7 +95,7 @@ inline std::string serialize(const NodePtr& root) {
         return "null";
 
     std::ostringstream stream;
-    std::qvector<NodePtr> queue;
+    qpp::qvector<NodePtr> queue;
     queue.push_back(root);
 
     bool first = true;
@@ -122,7 +122,7 @@ inline NodePtr deserialize(const std::string& data) {
     if (data == "null" || data.empty())
         return nullptr;
 
-    std::qvector<std::optional<int>> values;
+    qpp::qvector<std::optional<int>> values;
     std::size_t start = 0;
     while (start <= data.size()) {
         const auto end = data.find(',', start);
@@ -142,7 +142,7 @@ inline NodePtr deserialize(const std::string& data) {
         return nullptr;
 
     NodePtr root = make_node(*values.front());
-    std::qvector<NodePtr> queue;
+    qpp::qvector<NodePtr> queue;
     queue.push_back(root);
 
     std::size_t index = 1;
@@ -220,17 +220,17 @@ inline NodePtr lowest_common_ancestor_bst(NodePtr root, int value1, int value2) 
     return nullptr;
 }
 
-inline std::qvector<std::qvector<int>> level_order(const NodePtr& root) {
-    std::qvector<std::qvector<int>> levels;
+inline qpp::qvector<qpp::qvector<int>> level_order(const NodePtr& root) {
+    qpp::qvector<qpp::qvector<int>> levels;
     if (!root)
         return levels;
 
-    std::qvector<NodePtr> queue;
+    qpp::qvector<NodePtr> queue;
     queue.push_back(root);
 
     for (std::size_t front = 0; front < queue.size();) {
         const auto size = queue.size() - front;
-        std::qvector<int> level;
+        qpp::qvector<int> level;
         level.reserve(size);
 
         for (std::size_t index = 0; index < size; ++index) {
@@ -263,7 +263,7 @@ inline bool is_valid_bst(const NodePtr& root, std::optional<int> min = std::null
 }
 
 inline std::optional<int> kth_smallest(const NodePtr& root, int k) {
-    std::qvector<NodePtr> stack;
+    qpp::qvector<NodePtr> stack;
     auto current = root;
     int count = 0;
 
@@ -285,7 +285,7 @@ inline std::optional<int> kth_smallest(const NodePtr& root, int k) {
     return std::nullopt;
 }
 
-inline NodePtr build_tree_impl(const std::qvector<int>& preorder,
+inline NodePtr build_tree_impl(const qpp::qvector<int>& preorder,
                                std::size_t pre_left,
                                std::size_t pre_right,
                                const std::unordered_map<int, std::size_t>& inorder_index,
@@ -307,7 +307,7 @@ inline NodePtr build_tree_impl(const std::qvector<int>& preorder,
     return root;
 }
 
-inline NodePtr build_tree(const std::qvector<int>& preorder, const std::qvector<int>& inorder) {
+inline NodePtr build_tree(const qpp::qvector<int>& preorder, const qpp::qvector<int>& inorder) {
     if (preorder.size() != inorder.size() || preorder.empty())
         return nullptr;
 
@@ -337,7 +337,7 @@ inline int max_path_sum(const NodePtr& root) {
     return best;
 }
 
-inline std::string describe_levels(const std::qvector<std::qvector<int>>& levels) {
+inline std::string describe_levels(const qpp::qvector<qpp::qvector<int>>& levels) {
     std::ostringstream stream;
     stream << '[';
     for (std::size_t level_index = 0; level_index < levels.size(); ++level_index) {

--- a/examples/data-structures-and-algorithms/tree/tree_problems.qpp
+++ b/examples/data-structures-and-algorithms/tree/tree_problems.qpp
@@ -50,8 +50,8 @@ int main() {
     std::cout << "Kth Smallest Element in a BST\n  k=3: "
               << (kth ? std::to_string(*kth) : std::string{"not found"}) << "\n\n";
 
-    const std::qvector<int> preorder{3, 9, 20, 15, 7};
-    const std::qvector<int> inorder{9, 3, 15, 20, 7};
+    const qpp::qvector<int> preorder{3, 9, 20, 15, 7};
+    const qpp::qvector<int> inorder{9, 3, 15, 20, 7};
     auto constructed = build_tree(preorder, inorder);
     std::cout << "Construct Binary Tree From Preorder and Inorder Traversal\n  levels: "
               << describe_levels(level_order(constructed)) << "\n\n";

--- a/examples/data-structures-and-algorithms/trie/trie_problems.hpp
+++ b/examples/data-structures-and-algorithms/trie/trie_problems.hpp
@@ -158,8 +158,8 @@ class WordSearchTrie {
     std::unique_ptr<QuantumWordSearchNode> root_;
 };
 
-inline void dfs(std::qvector<std::string>& board, int row, int col,
-                QuantumWordSearchNode* node, std::qvector<std::string>& result,
+inline void dfs(qpp::qvector<std::string>& board, int row, int col,
+                QuantumWordSearchNode* node, qpp::qvector<std::string>& result,
                 qpp::pbool path_bias = qpp::pbool{1.0}) {
     const char letter = board[row][col];
     const auto index = static_cast<std::size_t>(letter - 'a');
@@ -190,8 +190,8 @@ inline void dfs(std::qvector<std::string>& board, int row, int col,
     board[row][col] = letter;
 }
 
-inline std::qvector<std::string> word_search_ii(
-    std::qvector<std::string> board, const std::qvector<std::string>& words) {
+inline qpp::qvector<std::string> word_search_ii(
+    qpp::qvector<std::string> board, const qpp::qvector<std::string>& words) {
     if (board.empty() || board.front().empty() || words.empty())
         return {};
 
@@ -199,7 +199,7 @@ inline std::qvector<std::string> word_search_ii(
     for (const auto& word : words)
         trie.insert(word);
 
-    std::qvector<std::string> result;
+    qpp::qvector<std::string> result;
     for (int row = 0; row < static_cast<int>(board.size()); ++row) {
         for (int col = 0; col < static_cast<int>(board.front().size()); ++col) {
             dfs(board, row, col, trie.root(), result);

--- a/examples/data-structures-and-algorithms/trie/trie_problems.qpp
+++ b/examples/data-structures-and-algorithms/trie/trie_problems.qpp
@@ -49,8 +49,8 @@ int main() {
     print_bias("search(\"b..\")", dictionary.search("b.."));
     std::cout << '\n';
 
-    std::qvector<std::string> board{"oaan", "etae", "ihkr", "iflv"};
-    const std::qvector<std::string> words{"oath", "pea", "eat", "rain"};
+    qpp::qvector<std::string> board{"oaan", "etae", "ihkr", "iflv"};
+    const qpp::qvector<std::string> words{"oath", "pea", "eat", "rain"};
     auto found = word_search_ii(board, words);
     std::sort(found.begin(), found.end());
 

--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.hpp
@@ -75,7 +75,7 @@ namespace detail {
 
 /// Measure each value to obtain classical integers for downstream processing.
 inline std::vector<int>
-collapse_two_pointer_inputs(const std::qvector<qint>& values) {
+collapse_two_pointer_inputs(const qpp::qvector<qint>& values) {
     std::vector<int> collapsed;
     collapsed.reserve(values.size());
 
@@ -139,12 +139,12 @@ inline std::vector<std::array<int, 3>> three_sum(std::vector<int> nums) {
 /// Enumerate all unique triplets that sum to zero for quantum integers by
 /// measuring inputs and lifting the classical results back into quantum
 /// registers.
-inline std::qvector<std::array<qint, 3>>
-quantum_three_sum(const std::qvector<qint>& nums) {
+inline qpp::qvector<std::array<qint, 3>>
+quantum_three_sum(const qpp::qvector<qint>& nums) {
     const auto collapsed = detail::collapse_two_pointer_inputs(nums);
     const auto classical = three_sum(collapsed);
 
-    std::qvector<std::array<qint, 3>> lifted;
+    qpp::qvector<std::array<qint, 3>> lifted;
     lifted.reserve(classical.size());
     for (const auto& triplet : classical)
         lifted.push_back(detail::lift_three_sum_triplet(triplet));
@@ -178,7 +178,7 @@ inline int container_with_most_water(const std::vector<int>& height) {
 /// Quantum wrapper that measures inputs then lifts the area back into a
 /// freshly-allocated quantum register.
 inline qint
-quantum_container_with_most_water(const std::qvector<qint>& height) {
+quantum_container_with_most_water(const qpp::qvector<qint>& height) {
     const auto collapsed = detail::collapse_two_pointer_inputs(height);
     return detail::make_quantum_value(container_with_most_water(collapsed));
 }

--- a/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
+++ b/examples/data-structures-and-algorithms/two-pointers/two_pointers.qpp
@@ -43,12 +43,12 @@ int main() {
 
     static_assert(std::is_same_v<decltype(three_sum(std::vector<int>{})),
                                  std::vector<std::array<int, 3>>>);
-    static_assert(std::is_same_v<decltype(quantum_three_sum(std::qvector<::qint>{})),
-                                 std::qvector<std::array<::qint, 3>>>);
+    static_assert(std::is_same_v<decltype(quantum_three_sum(qpp::qvector<::qint>{})),
+                                 qpp::qvector<std::array<::qint, 3>>>);
     static_assert(std::is_same_v<decltype(container_with_most_water(std::vector<int>{})),
                                  int>);
     static_assert(
-        std::is_same_v<decltype(quantum_container_with_most_water(std::qvector<::qint>{})),
+        std::is_same_v<decltype(quantum_container_with_most_water(qpp::qvector<::qint>{})),
                        ::qint>);
 
     std::cout << std::boolalpha;
@@ -76,7 +76,7 @@ int main() {
                   << "]\n";
     }
 
-    const std::qvector<::qint> quantum_nums{
+    const qpp::qvector<::qint> quantum_nums{
         static_cast<::qint>(-1),
         static_cast<::qint>(0),
         static_cast<::qint>(1),
@@ -96,7 +96,7 @@ int main() {
     std::cout << "container_with_most_water([1,8,6,2,5,4,8,3,7]) -> "
               << container_with_most_water(heights) << '\n';
 
-    const std::qvector<::qint> quantum_heights{
+    const qpp::qvector<::qint> quantum_heights{
         static_cast<::qint>(1),
         static_cast<::qint>(8),
         static_cast<::qint>(6),

--- a/include/qpp/backend/notifications.hpp
+++ b/include/qpp/backend/notifications.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstddef>
+#include <functional>
+#include <mutex>
+#include <string_view>
+
+namespace qpp::backend {
+
+/// Kind of notification emitted by quantum-aware containers.
+enum class NotificationKind { Clone, Measurement };
+
+/// Detailed description of an emitted notification.
+struct Notification {
+    NotificationKind kind{NotificationKind::Clone};
+    std::string_view source{};
+    std::size_t size = 0;
+    std::size_t index = 0;
+    double probability = 0.0;
+};
+
+using NotificationSink = std::function<void(const Notification&)>;
+
+/// Install a sink that receives backend notifications. Passing an empty
+/// std::function disables notifications.
+inline NotificationSink& sink_instance() {
+    static NotificationSink sink;
+    return sink;
+}
+
+inline std::mutex& sink_mutex() {
+    static std::mutex mtx;
+    return mtx;
+}
+
+inline void set_notification_sink(NotificationSink sink) {
+    std::lock_guard<std::mutex> lock(sink_mutex());
+    sink_instance() = std::move(sink);
+}
+
+/// Emit a notification to the currently installed sink, if any.
+inline void notify(Notification notification) {
+    NotificationSink current;
+    {
+        std::lock_guard<std::mutex> lock(sink_mutex());
+        current = sink_instance();
+    }
+    if (current)
+        current(notification);
+}
+
+} // namespace qpp::backend
+

--- a/include/qpp/quantum/state.hpp
+++ b/include/qpp/quantum/state.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstddef>
+#include <vector>
+
+namespace qpp::quantum {
+
+struct qstate {
+    std::vector<std::complex<double>> amplitude{};
+    mutable std::vector<double> probabilities{};
+    mutable bool probabilities_dirty = true;
+};
+
+inline void assign_uniform(qstate& state, std::size_t count) {
+    state.amplitude.assign(count, {0.0, 0.0});
+    state.probabilities.assign(count, 0.0);
+    if (count == 0) {
+        state.probabilities_dirty = false;
+        return;
+    }
+    const double amplitude = 1.0 / std::sqrt(static_cast<double>(count));
+    for (auto& amp : state.amplitude)
+        amp = {amplitude, 0.0};
+    std::fill(state.probabilities.begin(), state.probabilities.end(),
+              1.0 / static_cast<double>(count));
+    state.probabilities_dirty = false;
+}
+
+inline double amplitude_norm(const qstate& state) {
+    double total = 0.0;
+    for (const auto& amp : state.amplitude)
+        total += std::norm(amp);
+    return total;
+}
+
+inline void normalize_amplitudes(qstate& state) {
+    const double total = amplitude_norm(state);
+    if (state.amplitude.empty()) {
+        state.probabilities.clear();
+        state.probabilities_dirty = false;
+        return;
+    }
+    if (total == 0.0) {
+        assign_uniform(state, state.amplitude.size());
+        return;
+    }
+    const double inv = 1.0 / std::sqrt(total);
+    for (auto& amp : state.amplitude)
+        amp *= inv;
+    state.probabilities_dirty = true;
+}
+
+inline void ensure_probabilities(qstate& state) {
+    if (!state.probabilities_dirty)
+        return;
+    state.probabilities.resize(state.amplitude.size(), 0.0);
+    const double total = amplitude_norm(state);
+    if (total == 0.0) {
+        if (!state.amplitude.empty()) {
+            const double uniform = 1.0 / static_cast<double>(state.amplitude.size());
+            std::fill(state.probabilities.begin(), state.probabilities.end(), uniform);
+        }
+        state.probabilities_dirty = false;
+        return;
+    }
+    const double inv = 1.0 / total;
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i)
+        state.probabilities[i] = std::norm(state.amplitude[i]) * inv;
+    state.probabilities_dirty = false;
+}
+
+inline void resize_preserving_norm(qstate& state, std::size_t count) {
+    const std::size_t old = state.amplitude.size();
+    if (old == count) {
+        if (count == 0)
+            state.probabilities_dirty = false;
+        return;
+    }
+    if (old == 0) {
+        assign_uniform(state, count);
+        return;
+    }
+    state.amplitude.resize(count, {0.0, 0.0});
+    state.probabilities_dirty = true;
+    if (count == 0) {
+        state.probabilities.clear();
+        state.probabilities_dirty = false;
+        return;
+    }
+    normalize_amplitudes(state);
+}
+
+inline void reset_state(qstate& state, std::size_t count) {
+    assign_uniform(state, count);
+}
+
+inline void mark_dirty(qstate& state) {
+    state.probabilities_dirty = true;
+}
+
+inline void collapse(qstate& state, std::size_t index) {
+    if (index >= state.amplitude.size())
+        return;
+    for (std::size_t i = 0; i < state.amplitude.size(); ++i)
+        state.amplitude[i] = (i == index) ? std::complex<double>{1.0, 0.0}
+                                          : std::complex<double>{0.0, 0.0};
+    state.probabilities.assign(state.amplitude.size(), 0.0);
+    if (index < state.probabilities.size())
+        state.probabilities[index] = 1.0;
+    state.probabilities_dirty = false;
+}
+
+inline double probability_of(qstate& state, std::size_t index) {
+    ensure_probabilities(state);
+    if (index >= state.probabilities.size())
+        return 0.0;
+    return state.probabilities[index];
+}
+
+} // namespace qpp::quantum
+

--- a/include/qpp/qvector
+++ b/include/qpp/qvector
@@ -1,18 +1,298 @@
 #pragma once
 
+#include <initializer_list>
+#include <iterator>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
-namespace std {
+#include "qpp/backend/notifications.hpp"
+#include "qpp/quantum/state.hpp"
 
-/**
- * @brief Alias exposing the standard dynamic array as a quantum vector.
- *
- * Providing this alias allows quantum-specific code to reference a qvector
- * while reusing the optimised implementation of `std::vector` and its
- * allocator-aware interface.
- */
+namespace qpp {
+
+/// Quantum-aware dynamic array that tracks amplitude metadata alongside
+/// classical storage.
 template <typename T, typename Allocator = std::allocator<T>>
-using qvector = std::vector<T, Allocator>;
+class qvector {
+public:
+    using value_type = T;
+    using allocator_type = Allocator;
+    using size_type = typename std::vector<T, Allocator>::size_type;
+    using difference_type = typename std::vector<T, Allocator>::difference_type;
+    using reference = T&;
+    using const_reference = const T&;
+    using pointer = typename std::vector<T, Allocator>::pointer;
+    using const_pointer = typename std::vector<T, Allocator>::const_pointer;
+    using iterator = typename std::vector<T, Allocator>::iterator;
+    using const_iterator = typename std::vector<T, Allocator>::const_iterator;
+    using reverse_iterator = typename std::vector<T, Allocator>::reverse_iterator;
+    using const_reverse_iterator = typename std::vector<T, Allocator>::const_reverse_iterator;
 
-} // namespace std
+    qvector() noexcept(std::is_nothrow_default_constructible_v<std::vector<T, Allocator>>)
+        : data_{}, state_{} {}
+
+    explicit qvector(const Allocator& alloc)
+        : data_{alloc}, state_{} {}
+
+    explicit qvector(size_type count, const T& value = T(),
+                     const Allocator& alloc = Allocator())
+        : data_(count, value, alloc), state_{} {
+        quantum::reset_state(state_, data_.size());
+    }
+
+    explicit qvector(size_type count, const Allocator& alloc)
+        : data_(count, alloc), state_{} {
+        quantum::reset_state(state_, data_.size());
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral_v<InputIt>>>
+    qvector(InputIt first, InputIt last, const Allocator& alloc = Allocator())
+        : data_(first, last, alloc), state_{} {
+        quantum::reset_state(state_, data_.size());
+    }
+
+    qvector(std::initializer_list<T> init, const Allocator& alloc = Allocator())
+        : data_(init, alloc), state_{} {
+        quantum::reset_state(state_, data_.size());
+    }
+
+    qvector(const qvector& other)
+        : data_(other.data_), state_(other.state_) {
+        backend::notify({backend::NotificationKind::Clone, "qvector", data_.size(), 0, 0.0});
+    }
+
+    qvector(qvector&& other) noexcept(
+        std::is_nothrow_move_constructible_v<std::vector<T, Allocator>>)
+        : data_(std::move(other.data_)), state_(std::move(other.state_)) {}
+
+    qvector(const std::vector<T, Allocator>& other, const Allocator& alloc = Allocator())
+        : data_(other, alloc), state_{} {
+        quantum::reset_state(state_, data_.size());
+    }
+
+    ~qvector() = default;
+
+    qvector& operator=(const qvector& other) {
+        if (this == &other)
+            return *this;
+        data_ = other.data_;
+        state_ = other.state_;
+        backend::notify({backend::NotificationKind::Clone, "qvector", data_.size(), 0, 0.0});
+        return *this;
+    }
+
+    qvector& operator=(qvector&& other) noexcept(
+        std::is_nothrow_move_assignable_v<std::vector<T, Allocator>>) {
+        if (this == &other)
+            return *this;
+        data_ = std::move(other.data_);
+        state_ = std::move(other.state_);
+        return *this;
+    }
+
+    qvector& operator=(std::initializer_list<T> init) {
+        data_.assign(init.begin(), init.end());
+        quantum::reset_state(state_, data_.size());
+        return *this;
+    }
+
+    void assign(size_type count, const T& value) {
+        data_.assign(count, value);
+        quantum::reset_state(state_, data_.size());
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral_v<InputIt>>>
+    void assign(InputIt first, InputIt last) {
+        data_.assign(first, last);
+        quantum::reset_state(state_, data_.size());
+    }
+
+    void assign(std::initializer_list<T> ilist) {
+        assign(ilist.begin(), ilist.end());
+    }
+
+    [[nodiscard]] allocator_type get_allocator() const { return data_.get_allocator(); }
+
+    [[nodiscard]] reference at(size_type pos) { return data_.at(pos); }
+    [[nodiscard]] const_reference at(size_type pos) const { return data_.at(pos); }
+
+    [[nodiscard]] reference operator[](size_type pos) { return data_[pos]; }
+    [[nodiscard]] const_reference operator[](size_type pos) const { return data_[pos]; }
+
+    [[nodiscard]] reference front() { return data_.front(); }
+    [[nodiscard]] const_reference front() const { return data_.front(); }
+
+    [[nodiscard]] reference back() { return data_.back(); }
+    [[nodiscard]] const_reference back() const { return data_.back(); }
+
+    [[nodiscard]] pointer data() noexcept { return data_.data(); }
+    [[nodiscard]] const_pointer data() const noexcept { return data_.data(); }
+
+    [[nodiscard]] iterator begin() noexcept { return data_.begin(); }
+    [[nodiscard]] const_iterator begin() const noexcept { return data_.begin(); }
+    [[nodiscard]] const_iterator cbegin() const noexcept { return data_.cbegin(); }
+
+    [[nodiscard]] iterator end() noexcept { return data_.end(); }
+    [[nodiscard]] const_iterator end() const noexcept { return data_.end(); }
+    [[nodiscard]] const_iterator cend() const noexcept { return data_.cend(); }
+
+    [[nodiscard]] reverse_iterator rbegin() noexcept { return data_.rbegin(); }
+    [[nodiscard]] const_reverse_iterator rbegin() const noexcept { return data_.rbegin(); }
+    [[nodiscard]] const_reverse_iterator crbegin() const noexcept { return data_.crbegin(); }
+
+    [[nodiscard]] reverse_iterator rend() noexcept { return data_.rend(); }
+    [[nodiscard]] const_reverse_iterator rend() const noexcept { return data_.rend(); }
+    [[nodiscard]] const_reverse_iterator crend() const noexcept { return data_.crend(); }
+
+    [[nodiscard]] bool empty() const noexcept { return data_.empty(); }
+    [[nodiscard]] size_type size() const noexcept { return data_.size(); }
+    [[nodiscard]] size_type max_size() const noexcept { return data_.max_size(); }
+
+    void reserve(size_type new_cap) { data_.reserve(new_cap); }
+    [[nodiscard]] size_type capacity() const noexcept { return data_.capacity(); }
+    void shrink_to_fit() { data_.shrink_to_fit(); }
+
+    void clear() noexcept {
+        data_.clear();
+        quantum::reset_state(state_, 0);
+    }
+
+    iterator insert(const_iterator pos, const T& value) {
+        auto it = data_.insert(pos, value);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    iterator insert(const_iterator pos, T&& value) {
+        auto it = data_.insert(pos, std::move(value));
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    iterator insert(const_iterator pos, size_type count, const T& value) {
+        auto it = data_.insert(pos, count, value);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral_v<InputIt>>>
+    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+        auto it = data_.insert(pos, first, last);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    iterator insert(const_iterator pos, std::initializer_list<T> ilist) {
+        auto it = data_.insert(pos, ilist);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    template <typename... Args>
+    reference emplace_back(Args&&... args) {
+        data_.emplace_back(std::forward<Args>(args)...);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return data_.back();
+    }
+
+    template <typename... Args>
+    iterator emplace(const_iterator pos, Args&&... args) {
+        auto it = data_.emplace(pos, std::forward<Args>(args)...);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    void push_back(const T& value) {
+        data_.push_back(value);
+        quantum::resize_preserving_norm(state_, data_.size());
+    }
+
+    void push_back(T&& value) {
+        data_.push_back(std::move(value));
+        quantum::resize_preserving_norm(state_, data_.size());
+    }
+
+    void pop_back() {
+        data_.pop_back();
+        quantum::resize_preserving_norm(state_, data_.size());
+    }
+
+    iterator erase(const_iterator pos) {
+        auto it = data_.erase(pos);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        auto it = data_.erase(first, last);
+        quantum::resize_preserving_norm(state_, data_.size());
+        return it;
+    }
+
+    void resize(size_type count) {
+        const auto old_size = data_.size();
+        data_.resize(count);
+        adjust_state_after_resize(old_size);
+    }
+
+    void resize(size_type count, const value_type& value) {
+        const auto old_size = data_.size();
+        data_.resize(count, value);
+        adjust_state_after_resize(old_size);
+    }
+
+    void swap(qvector& other) noexcept(
+        noexcept(std::swap(std::declval<std::vector<T, Allocator>&>(),
+                            std::declval<std::vector<T, Allocator>&>()))) {
+        using std::swap;
+        swap(data_, other.data_);
+        swap(state_, other.state_);
+    }
+
+    [[nodiscard]] const quantum::qstate& state() const noexcept { return state_; }
+    [[nodiscard]] quantum::qstate& state() noexcept { return state_; }
+
+    [[nodiscard]] const std::vector<double>& probabilities() const {
+        quantum::ensure_probabilities(state_);
+        return state_.probabilities;
+    }
+
+    [[nodiscard]] double probability_of(size_type index) const {
+        quantum::ensure_probabilities(state_);
+        if (index >= state_.probabilities.size())
+            return 0.0;
+        return state_.probabilities[index];
+    }
+
+    const_reference measure(size_type index) {
+        const double p = probability_of(index);
+        quantum::collapse(state_, index);
+        backend::notify({backend::NotificationKind::Measurement, "qvector", data_.size(),
+                         index, p});
+        return data_.at(index);
+    }
+
+private:
+    void adjust_state_after_resize(size_type previous_size) {
+        if (previous_size == 0 && !data_.empty()) {
+            quantum::reset_state(state_, data_.size());
+            return;
+        }
+        quantum::resize_preserving_norm(state_, data_.size());
+    }
+
+    std::vector<T, Allocator> data_;
+    mutable quantum::qstate state_;
+};
+
+template <typename T, typename Allocator>
+void swap(qvector<T, Allocator>& lhs, qvector<T, Allocator>& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+    lhs.swap(rhs);
+}
+
+} // namespace qpp
 

--- a/qpp/tests/test_sim_algorithms.py
+++ b/qpp/tests/test_sim_algorithms.py
@@ -217,6 +217,72 @@ int main(){
         out = self.compile_and_run(code, 'qint_classical_measure')
         self.assertEqual(out, 'ok')
 
+    def test_qvector_superposition_and_measurement(self):
+        code = r"""#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <vector>
+#include "qpp/backend/notifications.hpp"
+#include "qpp/qvector"
+
+int main(){
+    using qpp::backend::Notification;
+    using qpp::backend::NotificationKind;
+    using qpp::backend::set_notification_sink;
+
+    std::vector<Notification> events;
+    set_notification_sink([&](const Notification& n){ events.push_back(n); });
+
+    qpp::qvector<int> values{1, 2, 3};
+    auto probs = values.probabilities();
+    if (probs.size() != 3)
+        return (std::cout << "fail\n", 0);
+    for (double p : probs)
+        if (std::abs(p - 1.0 / 3.0) > 1e-6)
+            return (std::cout << "fail\n", 0);
+
+    auto copy = values;
+    if (events.empty() || events.back().kind != NotificationKind::Clone)
+        return (std::cout << "fail\n", 0);
+
+    values.pop_back();
+    probs = values.probabilities();
+    if (probs.size() != 2)
+        return (std::cout << "fail\n", 0);
+    if (std::abs(probs[0] - 0.5) > 1e-6 || std::abs(probs[1] - 0.5) > 1e-6)
+        return (std::cout << "fail\n", 0);
+
+    const int measured = values.measure(1);
+    if (measured != 2)
+        return (std::cout << "fail\n", 0);
+
+    probs = values.probabilities();
+    if (probs.size() != 2)
+        return (std::cout << "fail\n", 0);
+    if (probs[0] > 1e-9 || std::abs(probs[1] - 1.0) > 1e-9)
+        return (std::cout << "fail\n", 0);
+
+    if (events.size() < 2)
+        return (std::cout << "fail\n", 0);
+    const auto& measure_event = events.back();
+    if (measure_event.kind != NotificationKind::Measurement || measure_event.index != 1)
+        return (std::cout << "fail\n", 0);
+    if (std::abs(measure_event.probability - 0.5) > 1e-6)
+        return (std::cout << "fail\n", 0);
+
+    const int total = std::accumulate(values.begin(), values.end(), 0);
+    if (total != 3)
+        return (std::cout << "fail\n", 0);
+
+    set_notification_sink({});
+    std::cout << "ok\n";
+    return 0;
+}
+"""
+        out = self.compile_and_run(code, 'qvector_superposition')
+        self.assertEqual(out, 'ok')
+
     def test_period_finding(self):
         code = r"""#include <iostream>
 #include "qpp/sim/PeriodFinding.hpp"


### PR DESCRIPTION
## Summary
- replace the `std::qvector` alias with a concrete `qpp::qvector` that tracks quantum state metadata and supports measurement APIs
- add reusable quantum state helpers and backend notification sinks to keep amplitudes normalised and report clone/measurement events
- update documentation, examples, and tests to use `qpp::qvector` and verify superposition safety and backend integration

## Testing
- pytest qpp/tests/test_sim_algorithms.py

------
https://chatgpt.com/codex/tasks/task_e_69010a411164832f8da9657a28e1b9d0