### PR TITLE
Implement quantum-aware qarray and qvector containers

### DIFF
--- a/docs/data-structures/quantum_containers.md
+++ b/docs/data-structures/quantum_containers.md
@@ -63,15 +63,35 @@ that hashed containers remain stable after the first observation.
 
 ## `qvector`: quantum-friendly dynamic arrays
 
-`std::qvector<T>` is a straightforward alias for `std::vector<T>` that resides in
-the standard namespace. The alias lets educational material refer to "quantum
-vectors" without sacrificing the familiarity or performance characteristics of
-the standard dynamic array. Any API that works with `std::vector`—iterators,
-capacity management, algorithms—works identically with `std::qvector`.
+`std::qvector<T>` wraps `std::vector<T>` while wiring in amplitude tracking and
+measurement bookkeeping. The container exposes the familiar dynamic-array
+interface—constructors, iterators, capacity helpers—but every mutating
+operation marks the underlying quantum state as "dirty". When you subsequently
+query `quantum_state()` the container recomputes a normalised amplitude buffer
+using the same weighting rules as `qint::prepare_normalized_amplitudes` and
+bumps its entanglement epoch counter. Sampling code can call `mark_measured()`
+to advance the measurement epoch, allowing tests to reason about collapsed vs
+uncollapsed views.
 
-When storing `qint` values, `std::qvector<qint>` becomes the natural building
-block for quantum sequences. You can reserve capacity, push states, and iterate
-with range-based `for` loops exactly as you would with classical data.
+Because the container is still backed by `std::vector`, existing examples that
+push, emplace, erase, or reserve behave exactly as before. The additional hooks
+ensure that adjacent quantum components—such as `entangled_set` or manual
+probability tracking—observe consistent state without forcing eager updates.
+
+## `qarray`: fixed-size quantum storage
+
+`std::qarray<T, N>` mirrors `std::array<T, N>` but feeds into the same amplitude
+bookkeeping used by `std::qvector`. Construction from classical `std::array`
+instances, C++20-style aggregate initialisation, and copy/move semantics all
+result in a deterministic `quantum_state()` with a lazily recomputed amplitude
+vector sized to the next power of two. Iterators and element accessors mark the
+internal state as dirty, so mutations performed through range-for loops or
+algorithms trigger a resynchronisation the next time amplitudes are queried.
+
+The container exposes the same epoch counters as `std::qvector`, making it easy
+to assert that copies do not accidentally share entanglement metadata and that
+measurement notifications propagate uniformly across both dynamic and fixed-size
+storage.
 
 ## `entangled_set`: context-aware hash sets
 

--- a/include/qpp/detail/quantum_container_bookkeeping.hpp
+++ b/include/qpp/detail/quantum_container_bookkeeping.hpp
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#include "qpp/qstruct.hpp"
+
+namespace qpp::detail::quantum_container {
+
+inline constexpr std::size_t qubits_for_length(std::size_t length) noexcept {
+    if (length == 0)
+        return 0;
+    std::size_t qubits = 0;
+    std::size_t capacity = 1;
+    while (capacity < length) {
+        capacity <<= 1U;
+        ++qubits;
+    }
+    return qubits;
+}
+
+template <typename T, typename = void> struct has_quantum_state : std::false_type {};
+
+template <typename T>
+struct has_quantum_state<T, std::void_t<decltype(std::declval<const T&>().quantum_state())>>
+    : std::true_type {};
+
+template <typename T> inline constexpr bool has_quantum_state_v = has_quantum_state<T>::value;
+
+template <typename T> inline double amplitude_value(std::size_t index, const T& value) {
+    if constexpr (std::is_arithmetic_v<T>) {
+        return static_cast<double>(value);
+    } else if constexpr (has_quantum_state_v<T>) {
+        const auto& state = value.quantum_state();
+        if (state.amplitude.empty())
+            return 0.0;
+        const std::size_t slot = std::min<std::size_t>(index, state.amplitude.size() - 1U);
+        return std::abs(state.amplitude[slot]);
+    } else {
+        (void)value;
+        return static_cast<double>(index + 1U);
+    }
+}
+
+class propagation_state {
+public:
+    constexpr propagation_state() = default;
+
+    constexpr void mark_dirty() const noexcept { amplitude_dirty_ = true; }
+
+    template <typename Iterator>
+    void ensure_amplitude(Iterator first, Iterator last) const {
+        if (!amplitude_dirty_)
+            return;
+        update_amplitude(first, last);
+    }
+
+    constexpr void note_measurement() const noexcept { ++measurement_epoch_; }
+
+    [[nodiscard]] constexpr std::size_t entanglement_version() const noexcept {
+        return entanglement_epoch_;
+    }
+
+    [[nodiscard]] constexpr std::size_t measurement_version() const noexcept {
+        return measurement_epoch_;
+    }
+
+    [[nodiscard]] const qpp::qstruct& amplitude() const noexcept { return amplitude_; }
+
+    void swap(propagation_state& other) noexcept {
+        using std::swap;
+        swap(amplitude_, other.amplitude_);
+        swap(amplitude_dirty_, other.amplitude_dirty_);
+        swap(entanglement_epoch_, other.entanglement_epoch_);
+        swap(measurement_epoch_, other.measurement_epoch_);
+    }
+
+private:
+    template <typename Iterator> void update_amplitude(Iterator first, Iterator last) const {
+        const std::size_t length = static_cast<std::size_t>(std::distance(first, last));
+        const std::size_t qubits = qubits_for_length(length);
+        const std::size_t capacity = length == 0 ? 0 : (std::size_t{1} << qubits);
+        amplitude_.amplitude.assign(std::max<std::size_t>(capacity, 1U), {0.0, 0.0});
+        if (length == 0) {
+            amplitude_.amplitude[0] = {1.0, 0.0};
+            amplitude_dirty_ = false;
+            ++entanglement_epoch_;
+            return;
+        }
+
+        double norm_accumulator = 0.0;
+        std::size_t index = 0;
+        for (Iterator it = first; it != last; ++it, ++index) {
+            const double base = amplitude_value(index, *it);
+            norm_accumulator += base * base;
+        }
+        const double normaliser = norm_accumulator > 0.0 ? std::sqrt(norm_accumulator) : 1.0;
+        index = 0;
+        for (Iterator it = first; it != last; ++it, ++index) {
+            const double base = amplitude_value(index, *it);
+            amplitude_.amplitude[index] = {base / normaliser, 0.0};
+        }
+        for (std::size_t i = index; i < amplitude_.amplitude.size(); ++i)
+            amplitude_.amplitude[i] = {0.0, 0.0};
+
+        amplitude_dirty_ = false;
+        ++entanglement_epoch_;
+    }
+
+    mutable qpp::qstruct amplitude_{};
+    mutable bool amplitude_dirty_{true};
+    mutable std::size_t entanglement_epoch_{0};
+    mutable std::size_t measurement_epoch_{0};
+};
+
+} // namespace qpp::detail::quantum_container
+

--- a/include/qpp/qarray
+++ b/include/qpp/qarray
@@ -1,18 +1,269 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <initializer_list>
+#include <iterator>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+
+#include "qpp/detail/quantum_container_bookkeeping.hpp"
 
 namespace std {
 
-/**
- * @brief Alias exposing the standard fixed-size array as a quantum array.
- *
- * Providing this alias allows quantum-specific code to reference a qarray
- * while reusing the optimised implementation of `std::array` and its
- * compile-time size guarantees.
- */
-template <typename T, std::size_t N>
-using qarray = std::array<T, N>;
+template <typename T, std::size_t N> class qarray {
+public:
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = T&;
+    using const_reference = const T&;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using iterator = T*;
+    using const_iterator = const T*;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    constexpr qarray() : data_{}, bookkeeping_{} { sync_quantum_state(); }
+
+    constexpr explicit qarray(const std::array<T, N>& classical)
+        : data_{classical}, bookkeeping_{} {
+        sync_quantum_state();
+    }
+
+    constexpr qarray(std::initializer_list<T> init) : data_{}, bookkeeping_{} {
+        if (init.size() > N)
+            throw std::length_error("initializer list larger than qarray");
+        std::size_t idx = 0;
+        for (const auto& value : init) {
+            data_[idx] = value;
+            ++idx;
+        }
+        for (; idx < N; ++idx)
+            data_[idx] = T{};
+        sync_quantum_state();
+    }
+
+    constexpr qarray(const qarray&) = default;
+    constexpr qarray(qarray&&) noexcept = default;
+    constexpr qarray& operator=(const qarray&) = default;
+    constexpr qarray& operator=(qarray&&) noexcept = default;
+
+    constexpr qarray& operator=(const std::array<T, N>& classical) {
+        data_ = classical;
+        bookkeeping_.mark_dirty();
+        return *this;
+    }
+
+    constexpr qarray& operator=(std::initializer_list<T> init) {
+        if (init.size() > N)
+            throw std::length_error("initializer list larger than qarray");
+        std::size_t idx = 0;
+        for (const auto& value : init) {
+            data_[idx] = value;
+            ++idx;
+        }
+        for (; idx < N; ++idx)
+            data_[idx] = T{};
+        bookkeeping_.mark_dirty();
+        return *this;
+    }
+
+    [[nodiscard]] static constexpr size_type size() noexcept { return N; }
+    [[nodiscard]] static constexpr size_type max_size() noexcept { return N; }
+    [[nodiscard]] static constexpr bool empty() noexcept { return N == 0; }
+
+    constexpr reference at(size_type pos) {
+        if (pos >= N)
+            throw std::out_of_range("qarray::at");
+        bookkeeping_.mark_dirty();
+        return data_[pos];
+    }
+
+    [[nodiscard]] constexpr const_reference at(size_type pos) const {
+        if (pos >= N)
+            throw std::out_of_range("qarray::at");
+        return data_[pos];
+    }
+
+    constexpr reference operator[](size_type pos) noexcept {
+        bookkeeping_.mark_dirty();
+        return data_[pos];
+    }
+
+    [[nodiscard]] constexpr const_reference operator[](size_type pos) const noexcept {
+        return data_[pos];
+    }
+
+    constexpr reference front() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.front();
+    }
+
+    [[nodiscard]] constexpr const_reference front() const noexcept { return data_.front(); }
+
+    constexpr reference back() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.back();
+    }
+
+    [[nodiscard]] constexpr const_reference back() const noexcept { return data_.back(); }
+
+    constexpr pointer data() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.data();
+    }
+
+    [[nodiscard]] constexpr const_pointer data() const noexcept { return data_.data(); }
+
+    constexpr iterator begin() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.data();
+    }
+
+    [[nodiscard]] constexpr const_iterator begin() const noexcept { return data_.data(); }
+    [[nodiscard]] constexpr const_iterator cbegin() const noexcept { return data_.data(); }
+
+    constexpr iterator end() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.data() + N;
+    }
+
+    [[nodiscard]] constexpr const_iterator end() const noexcept { return data_.data() + N; }
+    [[nodiscard]] constexpr const_iterator cend() const noexcept { return data_.data() + N; }
+
+    constexpr reverse_iterator rbegin() noexcept { return reverse_iterator(end()); }
+    [[nodiscard]] constexpr const_reverse_iterator rbegin() const noexcept {
+        return const_reverse_iterator(end());
+    }
+    [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(cend());
+    }
+
+    constexpr reverse_iterator rend() noexcept { return reverse_iterator(begin()); }
+    [[nodiscard]] constexpr const_reverse_iterator rend() const noexcept {
+        return const_reverse_iterator(begin());
+    }
+    [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(cbegin());
+    }
+
+    constexpr void fill(const T& value) {
+        data_.fill(value);
+        bookkeeping_.mark_dirty();
+    }
+
+    constexpr void swap(qarray& other) noexcept(std::is_nothrow_swappable<std::array<T, N>>::value) {
+        using std::swap;
+        swap(data_, other.data_);
+        bookkeeping_.swap(other.bookkeeping_);
+    }
+
+    friend constexpr void swap(qarray& lhs, qarray& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+        lhs.swap(rhs);
+    }
+
+    [[nodiscard]] constexpr const std::array<T, N>& classical() const noexcept { return data_; }
+
+    constexpr std::array<T, N>& classical() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_;
+    }
+
+    constexpr void mark_measured() const noexcept { bookkeeping_.note_measurement(); }
+
+    [[nodiscard]] constexpr std::size_t measurement_epoch() const noexcept {
+        return bookkeeping_.measurement_version();
+    }
+
+    [[nodiscard]] std::size_t entanglement_epoch() const {
+        sync_quantum_state();
+        return bookkeeping_.entanglement_version();
+    }
+
+    [[nodiscard]] const qpp::qstruct& quantum_state() const {
+        sync_quantum_state();
+        return bookkeeping_.amplitude();
+    }
+
+    friend constexpr bool operator==(const qarray& lhs, const qarray& rhs) {
+        return lhs.data_ == rhs.data_;
+    }
+
+    friend constexpr bool operator!=(const qarray& lhs, const qarray& rhs) {
+        return !(lhs == rhs);
+    }
+
+    friend constexpr bool operator<(const qarray& lhs, const qarray& rhs) {
+        return lhs.data_ < rhs.data_;
+    }
+
+    friend constexpr bool operator<=(const qarray& lhs, const qarray& rhs) {
+        return !(rhs < lhs);
+    }
+
+    friend constexpr bool operator>(const qarray& lhs, const qarray& rhs) { return rhs < lhs; }
+
+    friend constexpr bool operator>=(const qarray& lhs, const qarray& rhs) { return !(lhs < rhs); }
+
+private:
+    template <std::size_t Index> constexpr reference get_element() noexcept {
+        static_assert(Index < N, "qarray index out of bounds");
+        bookkeeping_.mark_dirty();
+        return data_[Index];
+    }
+
+    template <std::size_t Index> [[nodiscard]] constexpr const_reference get_element() const noexcept {
+        static_assert(Index < N, "qarray index out of bounds");
+        return data_[Index];
+    }
+
+    void sync_quantum_state() const {
+        bookkeeping_.ensure_amplitude(data_.begin(), data_.end());
+    }
+
+    std::array<T, N> data_{};
+    mutable qpp::detail::quantum_container::propagation_state bookkeeping_{};
+
+    template <std::size_t Index, typename U, std::size_t M>
+    friend constexpr U& get(qarray<U, M>&) noexcept;
+
+    template <std::size_t Index, typename U, std::size_t M>
+    friend constexpr const U& get(const qarray<U, M>&) noexcept;
+
+    template <std::size_t Index, typename U, std::size_t M>
+    friend constexpr U&& get(qarray<U, M>&&) noexcept;
+
+    template <std::size_t Index, typename U, std::size_t M>
+    friend constexpr const U&& get(const qarray<U, M>&&) noexcept;
+};
+
+template <std::size_t Index, typename T, std::size_t N> constexpr T& get(qarray<T, N>& arr) noexcept {
+    return arr.template get_element<Index>();
+}
+
+template <std::size_t Index, typename T, std::size_t N>
+constexpr const T& get(const qarray<T, N>& arr) noexcept {
+    return arr.template get_element<Index>();
+}
+
+template <std::size_t Index, typename T, std::size_t N>
+constexpr T&& get(qarray<T, N>&& arr) noexcept {
+    return std::move(arr.template get_element<Index>());
+}
+
+template <std::size_t Index, typename T, std::size_t N>
+constexpr const T&& get(const qarray<T, N>&& arr) noexcept {
+    return std::move(arr.template get_element<Index>());
+}
+
+template <typename T, std::size_t N> struct tuple_size<qarray<T, N>> : std::integral_constant<std::size_t, N> {};
+
+template <std::size_t Index, typename T, std::size_t N> struct tuple_element<Index, qarray<T, N>> {
+    using type = T;
+};
 
 } // namespace std
 

--- a/include/qpp/qvector
+++ b/include/qpp/qvector
@@ -1,18 +1,320 @@
 #pragma once
 
+#include <initializer_list>
+#include <iterator>
+#include <type_traits>
+#include <utility>
 #include <vector>
+
+#include "qpp/detail/quantum_container_bookkeeping.hpp"
 
 namespace std {
 
-/**
- * @brief Alias exposing the standard dynamic array as a quantum vector.
- *
- * Providing this alias allows quantum-specific code to reference a qvector
- * while reusing the optimised implementation of `std::vector` and its
- * allocator-aware interface.
- */
-template <typename T, typename Allocator = std::allocator<T>>
-using qvector = std::vector<T, Allocator>;
+template <typename T, typename Allocator = std::allocator<T>> class qvector {
+    using storage_type = std::vector<T, Allocator>;
+
+public:
+    using value_type = typename storage_type::value_type;
+    using allocator_type = typename storage_type::allocator_type;
+    using size_type = typename storage_type::size_type;
+    using difference_type = typename storage_type::difference_type;
+    using reference = typename storage_type::reference;
+    using const_reference = typename storage_type::const_reference;
+    using pointer = typename storage_type::pointer;
+    using const_pointer = typename storage_type::const_pointer;
+    using iterator = typename storage_type::iterator;
+    using const_iterator = typename storage_type::const_iterator;
+    using reverse_iterator = typename storage_type::reverse_iterator;
+    using const_reverse_iterator = typename storage_type::const_reverse_iterator;
+
+    qvector() = default;
+
+    explicit qvector(const allocator_type& alloc) : data_(alloc) { sync_quantum_state(); }
+
+    explicit qvector(size_type count, const allocator_type& alloc = allocator_type())
+        : data_(count, T{}, alloc) {
+        sync_quantum_state();
+    }
+
+    qvector(size_type count, const T& value, const allocator_type& alloc = allocator_type())
+        : data_(count, value, alloc) {
+        sync_quantum_state();
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral<InputIt>::value>>
+    qvector(InputIt first, InputIt last, const allocator_type& alloc = allocator_type())
+        : data_(first, last, alloc) {
+        sync_quantum_state();
+    }
+
+    qvector(std::initializer_list<T> init, const allocator_type& alloc = allocator_type())
+        : data_(init, alloc) {
+        sync_quantum_state();
+    }
+
+    qvector(const storage_type& classical) : data_(classical) { sync_quantum_state(); }
+
+    qvector(storage_type&& classical) noexcept(std::is_nothrow_move_constructible<storage_type>::value)
+        : data_(std::move(classical)) {
+        sync_quantum_state();
+    }
+
+    qvector(const qvector& other) = default;
+    qvector(qvector&& other) noexcept = default;
+
+    qvector& operator=(const qvector& other) {
+        if (this != &other) {
+            data_ = other.data_;
+            bookkeeping_ = other.bookkeeping_;
+            sync_quantum_state();
+        }
+        return *this;
+    }
+
+    qvector& operator=(qvector&& other) noexcept(std::is_nothrow_move_assignable<storage_type>::value) {
+        if (this != &other) {
+            data_ = std::move(other.data_);
+            bookkeeping_ = std::move(other.bookkeeping_);
+            sync_quantum_state();
+        }
+        return *this;
+    }
+
+    qvector& operator=(std::initializer_list<T> init) {
+        data_ = init;
+        bookkeeping_.mark_dirty();
+        sync_quantum_state();
+        return *this;
+    }
+
+    void assign(size_type count, const T& value) {
+        data_.assign(count, value);
+        bookkeeping_.mark_dirty();
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral<InputIt>::value>>
+    void assign(InputIt first, InputIt last) {
+        data_.assign(first, last);
+        bookkeeping_.mark_dirty();
+    }
+
+    void assign(std::initializer_list<T> init) {
+        data_.assign(init.begin(), init.end());
+        bookkeeping_.mark_dirty();
+    }
+
+    allocator_type get_allocator() const noexcept { return data_.get_allocator(); }
+
+    reference at(size_type pos) {
+        bookkeeping_.mark_dirty();
+        return data_.at(pos);
+    }
+
+    const_reference at(size_type pos) const { return data_.at(pos); }
+
+    reference operator[](size_type pos) {
+        bookkeeping_.mark_dirty();
+        return data_[pos];
+    }
+
+    const_reference operator[](size_type pos) const { return data_[pos]; }
+
+    reference front() {
+        bookkeeping_.mark_dirty();
+        return data_.front();
+    }
+
+    const_reference front() const { return data_.front(); }
+
+    reference back() {
+        bookkeeping_.mark_dirty();
+        return data_.back();
+    }
+
+    const_reference back() const { return data_.back(); }
+
+    pointer data() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.data();
+    }
+
+    const_pointer data() const noexcept { return data_.data(); }
+
+    iterator begin() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.begin();
+    }
+
+    const_iterator begin() const noexcept { return data_.begin(); }
+    const_iterator cbegin() const noexcept { return data_.cbegin(); }
+
+    iterator end() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.end();
+    }
+
+    const_iterator end() const noexcept { return data_.end(); }
+    const_iterator cend() const noexcept { return data_.cend(); }
+
+    reverse_iterator rbegin() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.rbegin();
+    }
+
+    const_reverse_iterator rbegin() const noexcept { return data_.rbegin(); }
+    const_reverse_iterator crbegin() const noexcept { return data_.crbegin(); }
+
+    reverse_iterator rend() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_.rend();
+    }
+
+    const_reverse_iterator rend() const noexcept { return data_.rend(); }
+    const_reverse_iterator crend() const noexcept { return data_.crend(); }
+
+    bool empty() const noexcept { return data_.empty(); }
+    size_type size() const noexcept { return data_.size(); }
+    size_type max_size() const noexcept { return data_.max_size(); }
+
+    void reserve(size_type new_cap) {
+        data_.reserve(new_cap);
+        bookkeeping_.mark_dirty();
+    }
+
+    size_type capacity() const noexcept { return data_.capacity(); }
+
+    void shrink_to_fit() {
+        data_.shrink_to_fit();
+        bookkeeping_.mark_dirty();
+    }
+
+    void clear() noexcept {
+        data_.clear();
+        bookkeeping_.mark_dirty();
+    }
+
+    iterator insert(const_iterator pos, const T& value) {
+        auto it = data_.insert(pos, value);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    iterator insert(const_iterator pos, T&& value) {
+        auto it = data_.insert(pos, std::move(value));
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    iterator insert(const_iterator pos, size_type count, const T& value) {
+        auto it = data_.insert(pos, count, value);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    template <typename InputIt,
+              typename = std::enable_if_t<!std::is_integral<InputIt>::value>>
+    iterator insert(const_iterator pos, InputIt first, InputIt last) {
+        auto it = data_.insert(pos, first, last);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    iterator insert(const_iterator pos, std::initializer_list<T> init) {
+        auto it = data_.insert(pos, init.begin(), init.end());
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    template <typename... Args> reference emplace_back(Args&&... args) {
+        bookkeeping_.mark_dirty();
+        return data_.emplace_back(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args> iterator emplace(const_iterator pos, Args&&... args) {
+        auto it = data_.emplace(pos, std::forward<Args>(args)...);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    void push_back(const T& value) {
+        data_.push_back(value);
+        bookkeeping_.mark_dirty();
+    }
+
+    void push_back(T&& value) {
+        data_.push_back(std::move(value));
+        bookkeeping_.mark_dirty();
+    }
+
+    void pop_back() {
+        data_.pop_back();
+        bookkeeping_.mark_dirty();
+    }
+
+    iterator erase(const_iterator pos) {
+        auto it = data_.erase(pos);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    iterator erase(const_iterator first, const_iterator last) {
+        auto it = data_.erase(first, last);
+        bookkeeping_.mark_dirty();
+        return it;
+    }
+
+    void resize(size_type count) {
+        data_.resize(count);
+        bookkeeping_.mark_dirty();
+    }
+
+    void resize(size_type count, const value_type& value) {
+        data_.resize(count, value);
+        bookkeeping_.mark_dirty();
+    }
+
+    void swap(qvector& other) noexcept(
+        noexcept(std::declval<storage_type&>().swap(std::declval<storage_type&>()))) {
+        using std::swap;
+        swap(data_, other.data_);
+        bookkeeping_.swap(other.bookkeeping_);
+    }
+
+    friend void swap(qvector& lhs, qvector& rhs) noexcept(noexcept(lhs.swap(rhs))) {
+        lhs.swap(rhs);
+    }
+
+    storage_type& classical() noexcept {
+        bookkeeping_.mark_dirty();
+        return data_;
+    }
+
+    const storage_type& classical() const noexcept { return data_; }
+
+    void mark_measured() const noexcept { bookkeeping_.note_measurement(); }
+
+    std::size_t measurement_epoch() const noexcept { return bookkeeping_.measurement_version(); }
+
+    std::size_t entanglement_epoch() const {
+        sync_quantum_state();
+        return bookkeeping_.entanglement_version();
+    }
+
+    const qpp::qstruct& quantum_state() const {
+        sync_quantum_state();
+        return bookkeeping_.amplitude();
+    }
+
+private:
+    void sync_quantum_state() const {
+        bookkeeping_.ensure_amplitude(data_.begin(), data_.end());
+    }
+
+    storage_type data_{};
+    mutable qpp::detail::quantum_container::propagation_state bookkeeping_{};
+};
 
 } // namespace std
 

--- a/qpp/tests/test_sim_algorithms.py
+++ b/qpp/tests/test_sim_algorithms.py
@@ -217,6 +217,91 @@ int main(){
         out = self.compile_and_run(code, 'qint_classical_measure')
         self.assertEqual(out, 'ok')
 
+    def test_qarray_initialization_and_state(self):
+        code = r"""#include <array>
+#include <cmath>
+#include <iostream>
+#include "qpp/qarray"
+
+int main() {
+    const std::array<int, 3> classical{{1, 2, 3}};
+    std::qarray<int, 3> quantum(classical);
+    const auto& state = quantum.quantum_state();
+    if (state.amplitude.size() != 4)
+        return 1;
+    const double normaliser = std::sqrt(14.0);
+    bool ok = true;
+    ok &= std::abs(state.amplitude[0].real() - (1.0 / normaliser)) < 1e-9;
+    ok &= std::abs(state.amplitude[1].real() - (2.0 / normaliser)) < 1e-9;
+    ok &= std::abs(state.amplitude[2].real() - (3.0 / normaliser)) < 1e-9;
+    ok &= std::abs(state.amplitude[3].real()) < 1e-12;
+    const auto before = quantum.measurement_epoch();
+    quantum.mark_measured();
+    ok &= quantum.measurement_epoch() == before + 1;
+    std::cout << (ok ? "ok" : "fail") << '\n';
+    return ok ? 0 : 1;
+}
+"""
+        out = self.compile_and_run(code, 'qarray_init_state')
+        self.assertEqual(out, 'ok')
+
+    def test_qarray_copy_move_entanglement(self):
+        code = r"""#include <cmath>
+#include <iostream>
+#include "qpp/qarray"
+
+int main() {
+    std::qarray<int, 3> source{1, 2, 3};
+    auto baseline_state = source.quantum_state();
+    const double normaliser = std::sqrt(14.0);
+    bool ok = std::abs(baseline_state.amplitude[0].real() - (1.0 / normaliser)) < 1e-9;
+
+    std::qarray<int, 3> copy = source;
+    copy[0] = 42;
+    const auto copy_state = copy.quantum_state();
+    ok &= std::abs(copy_state.amplitude[0].real() - (42.0 / std::sqrt(42.0 * 42.0 + 2.0 * 2.0 + 3.0 * 3.0))) < 1e-9;
+    const auto source_state = source.quantum_state();
+    ok &= std::abs(source_state.amplitude[0].real() - (1.0 / normaliser)) < 1e-9;
+
+    std::qarray<int, 3> moved = std::move(copy);
+    moved[1] = -1;
+    const auto moved_state = moved.quantum_state();
+    ok &= moved_state.amplitude.size() == 4;
+
+    const auto before_measure = source.measurement_epoch();
+    source.mark_measured();
+    ok &= source.measurement_epoch() == before_measure + 1;
+    std::cout << (ok ? "ok" : "fail") << '\n';
+    return ok ? 0 : 1;
+}
+"""
+        out = self.compile_and_run(code, 'qarray_copy_move')
+        self.assertEqual(out, 'ok')
+
+    def test_qarray_matches_qvector_state(self):
+        code = r"""#include <cmath>
+#include <iostream>
+#include "qpp/qarray"
+#include "qpp/qvector"
+
+int main() {
+    std::qarray<int, 3> quantum_array{2, 1, 0};
+    std::qvector<int> quantum_vector{2, 1, 0};
+    const auto& array_state = quantum_array.quantum_state();
+    const auto& vector_state = quantum_vector.quantum_state();
+    if (array_state.amplitude.size() != vector_state.amplitude.size())
+        return 1;
+    bool ok = true;
+    for (std::size_t i = 0; i < array_state.amplitude.size(); ++i) {
+        ok &= std::abs(array_state.amplitude[i].real() - vector_state.amplitude[i].real()) < 1e-9;
+    }
+    std::cout << (ok ? "ok" : "fail") << '\n';
+    return ok ? 0 : 1;
+}
+"""
+        out = self.compile_and_run(code, 'qarray_qvector_sync')
+        self.assertEqual(out, 'ok')
+
     def test_period_finding(self):
         code = r"""#include <iostream>
 #include "qpp/sim/PeriodFinding.hpp"


### PR DESCRIPTION
## Summary
- add shared quantum_container bookkeeping to synchronise amplitude, measurement, and entanglement metadata
- replace std::qarray alias with a fixed-size container leveraging the shared hooks and expose helper accessors
- upgrade std::qvector to participate in the new bookkeeping, refresh documentation, and extend tests for the new behaviours

## Testing
- python3 -m pytest qpp/tests/test_sim_algorithms.py

------
https://chatgpt.com/codex/tasks/task_e_69010a430dc8832f92653c114273fd40